### PR TITLE
Fix dxt build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ You can install this server as a Desktop Extension for Claude Desktop using the 
 1. Build and pack:
    ```bash
    npm run build
-   npx dxt pack
+   npx @anthropic-ai/dxt pack
    ```
    This produces `fastmail-mcp.dxt` in the project root.
 


### PR DESCRIPTION
Instructions indicated running npx dxt, which doesn't work (by default, without dxt being installed locally), so we should really have the full path there.