### PR TITLE
fix: include sender display name in outgoing emails

### DIFF
--- a/src/jmap-client.ts
+++ b/src/jmap-client.ts
@@ -238,7 +238,7 @@ export class JmapClient {
     const emailObject = {
       mailboxIds: initialMailboxIds,
       keywords: { $draft: true },
-      from: [{ email: fromEmail }],
+      from: [{ name: selectedIdentity.name, email: fromEmail }],
       to: email.to.map(addr => ({ email: addr })),
       cc: email.cc?.map(addr => ({ email: addr })) || [],
       bcc: email.bcc?.map(addr => ({ email: addr })) || [],


### PR DESCRIPTION
## Summary
- Include the identity's `name` property in the `from` field when sending emails via JMAP
- Previously only the email address was included, causing sent emails to show just the email address without the sender's display name

## Changes
One-line fix in `src/jmap-client.ts`:
```diff
- from: [{ email: fromEmail }],
+ from: [{ name: selectedIdentity.name, email: fromEmail }],
```

## Test plan
- [x] Send email via MCP and verify sender name appears correctly in recipient's inbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)