### PR TITLE
feat: add reply_email tool with proper threading support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,26 @@
 {
   "name": "fastmail-mcp",
-  "version": "1.0.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fastmail-mcp",
-      "version": "1.0.0",
+      "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^0.6.0",
-        "node-fetch": "^3.3.2"
+        "@modelcontextprotocol/sdk": "^0.6.0"
+      },
+      "bin": {
+        "fastmail-mcp": "dist/index.js"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
         "tsx": "^4.0.0",
         "typescript": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -482,15 +487,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -539,41 +535,6 @@
         "@esbuild/win32-arm64": "0.25.5",
         "@esbuild/win32-ia32": "0.25.5",
         "@esbuild/win32-x64": "0.25.5"
-      }
-    },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/fsevents": {
@@ -637,44 +598,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
     },
     "node_modules/raw-body": {
       "version": "3.0.0",
@@ -779,15 +702,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/zod": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -272,6 +272,57 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         },
       },
       {
+        name: 'save_draft',
+        description: 'Save an email as a draft without sending it. Supports threading headers for replies.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            to: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Recipient email addresses',
+            },
+            cc: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'CC email addresses (optional)',
+            },
+            bcc: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'BCC email addresses (optional)',
+            },
+            from: {
+              type: 'string',
+              description: 'Sender email address (optional, defaults to account primary email)',
+            },
+            subject: {
+              type: 'string',
+              description: 'Email subject',
+            },
+            textBody: {
+              type: 'string',
+              description: 'Plain text body (optional)',
+            },
+            htmlBody: {
+              type: 'string',
+              description: 'HTML body (optional)',
+            },
+            inReplyTo: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Message-IDs to reply to (optional, for threading)',
+            },
+            references: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Message-IDs for References header (optional, for threading)',
+            },
+          },
+          required: ['to', 'subject'],
+        },
+      },
+      {
         name: 'search_emails',
         description: 'Search emails by subject or content',
         inputSchema: {
@@ -501,6 +552,44 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         },
       },
       {
+        name: 'add_labels',
+        description: 'Add labels (mailboxes) to an email without removing existing ones',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            emailId: {
+              type: 'string',
+              description: 'ID of the email to add labels to',
+            },
+            mailboxIds: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Array of mailbox IDs to add as labels',
+            },
+          },
+          required: ['emailId', 'mailboxIds'],
+        },
+      },
+      {
+        name: 'remove_labels',
+        description: 'Remove specific labels (mailboxes) from an email',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            emailId: {
+              type: 'string',
+              description: 'ID of the email to remove labels from',
+            },
+            mailboxIds: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Array of mailbox IDs to remove as labels',
+            },
+          },
+          required: ['emailId', 'mailboxIds'],
+        },
+      },
+      {
         name: 'get_email_attachments',
         description: 'Get list of attachments for an email',
         inputSchema: {
@@ -669,6 +758,46 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
           },
           required: ['emailIds'],
+        },
+      },
+      {
+        name: 'bulk_add_labels',
+        description: 'Add labels to multiple emails simultaneously',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            emailIds: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Array of email IDs to add labels to',
+            },
+            mailboxIds: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Array of mailbox IDs to add as labels',
+            },
+          },
+          required: ['emailIds', 'mailboxIds'],
+        },
+      },
+      {
+        name: 'bulk_remove_labels',
+        description: 'Remove labels from multiple emails simultaneously',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            emailIds: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Array of email IDs to remove labels from',
+            },
+            mailboxIds: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Array of mailbox IDs to remove as labels',
+            },
+          },
+          required: ['emailIds', 'mailboxIds'],
         },
       },
       {
@@ -842,6 +971,40 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             {
               type: 'text',
               text: `Reply sent successfully. Submission ID: ${submissionId}`,
+            },
+          ],
+        };
+      }
+
+      case 'save_draft': {
+        const { to, cc, bcc, from, subject, textBody, htmlBody, inReplyTo, references } = args as any;
+        if (!to || !Array.isArray(to) || to.length === 0) {
+          throw new McpError(ErrorCode.InvalidParams, 'to field is required and must be a non-empty array');
+        }
+        if (!subject) {
+          throw new McpError(ErrorCode.InvalidParams, 'subject is required');
+        }
+        if (!textBody && !htmlBody) {
+          throw new McpError(ErrorCode.InvalidParams, 'Either textBody or htmlBody is required');
+        }
+
+        const draftId = await client.saveDraft({
+          to,
+          cc,
+          bcc,
+          from,
+          subject,
+          textBody,
+          htmlBody,
+          inReplyTo,
+          references,
+        });
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Draft saved successfully. Draft ID: ${draftId}`,
             },
           ],
         };
@@ -1081,6 +1244,46 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
       }
 
+      case 'add_labels': {
+        const { emailId, mailboxIds } = args as any;
+        if (!emailId) {
+          throw new McpError(ErrorCode.InvalidParams, 'emailId is required');
+        }
+        if (!mailboxIds || !Array.isArray(mailboxIds) || mailboxIds.length === 0) {
+          throw new McpError(ErrorCode.InvalidParams, 'mailboxIds array is required and must not be empty');
+        }
+        const client = initializeClient();
+        await client.addLabels(emailId, mailboxIds);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Labels added successfully to email`,
+            },
+          ],
+        };
+      }
+
+      case 'remove_labels': {
+        const { emailId, mailboxIds } = args as any;
+        if (!emailId) {
+          throw new McpError(ErrorCode.InvalidParams, 'emailId is required');
+        }
+        if (!mailboxIds || !Array.isArray(mailboxIds) || mailboxIds.length === 0) {
+          throw new McpError(ErrorCode.InvalidParams, 'mailboxIds array is required and must not be empty');
+        }
+        const client = initializeClient();
+        await client.removeLabels(emailId, mailboxIds);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Labels removed successfully from email`,
+            },
+          ],
+        };
+      }
+
       case 'get_email_attachments': {
         const { emailId } = args as any;
         if (!emailId) {
@@ -1242,6 +1445,46 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
       }
 
+      case 'bulk_add_labels': {
+        const { emailIds, mailboxIds } = args as any;
+        if (!emailIds || !Array.isArray(emailIds) || emailIds.length === 0) {
+          throw new McpError(ErrorCode.InvalidParams, 'emailIds array is required and must not be empty');
+        }
+        if (!mailboxIds || !Array.isArray(mailboxIds) || mailboxIds.length === 0) {
+          throw new McpError(ErrorCode.InvalidParams, 'mailboxIds array is required and must not be empty');
+        }
+        const client = initializeClient();
+        await client.bulkAddLabels(emailIds, mailboxIds);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Labels added successfully to ${emailIds.length} emails`,
+            },
+          ],
+        };
+      }
+
+      case 'bulk_remove_labels': {
+        const { emailIds, mailboxIds } = args as any;
+        if (!emailIds || !Array.isArray(emailIds) || emailIds.length === 0) {
+          throw new McpError(ErrorCode.InvalidParams, 'emailIds array is required and must not be empty');
+        }
+        if (!mailboxIds || !Array.isArray(mailboxIds) || mailboxIds.length === 0) {
+          throw new McpError(ErrorCode.InvalidParams, 'mailboxIds array is required and must not be empty');
+        }
+        const client = initializeClient();
+        await client.bulkRemoveLabels(emailIds, mailboxIds);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Labels removed successfully from ${emailIds.length} emails`,
+            },
+          ],
+        };
+      }
+
       case 'check_function_availability': {
         const client = initializeClient();
         const session = await client.getSession();
@@ -1253,7 +1496,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
               'list_mailboxes', 'list_emails', 'get_email', 'send_email', 'search_emails',
               'get_recent_emails', 'mark_email_read', 'delete_email', 'move_email',
               'get_email_attachments', 'download_attachment', 'advanced_search', 'get_thread',
-              'get_mailbox_stats', 'get_account_summary', 'bulk_mark_read', 'bulk_move', 'bulk_delete'
+              'get_mailbox_stats', 'get_account_summary', 'bulk_mark_read', 'bulk_move', 'bulk_delete',
+              'add_labels', 'remove_labels', 'bulk_add_labels', 'bulk_remove_labels'
             ]
           },
           identity: {

--- a/src/jmap-client.ts
+++ b/src/jmap-client.ts
@@ -301,6 +301,95 @@ export class JmapClient {
     return submissionResult.created?.submission?.id || 'unknown';
   }
 
+  async saveDraft(email: {
+    to: string[];
+    cc?: string[];
+    bcc?: string[];
+    subject: string;
+    textBody?: string;
+    htmlBody?: string;
+    from?: string;
+    inReplyTo?: string[];
+    references?: string[];
+  }): Promise<string> {
+    const session = await this.getSession();
+
+    // Get all identities to validate from address
+    const identities = await this.getIdentities();
+    if (!identities || identities.length === 0) {
+      throw new Error('No sending identities found');
+    }
+
+    // Determine which identity to use
+    let selectedIdentity;
+    if (email.from) {
+      selectedIdentity = identities.find(id => 
+        id.email.toLowerCase() === email.from?.toLowerCase()
+      );
+      if (!selectedIdentity) {
+        throw new Error('From address is not verified for sending. Choose one of your verified identities.');
+      }
+    } else {
+      selectedIdentity = identities.find(id => id.mayDelete === false) || identities[0];
+    }
+
+    const fromEmail = selectedIdentity.email;
+
+    // Get the Drafts mailbox
+    const mailboxes = await this.getMailboxes();
+    const draftsMailbox = mailboxes.find(mb => mb.role === 'drafts') || mailboxes.find(mb => mb.name.toLowerCase().includes('draft'));
+    
+    if (!draftsMailbox) {
+      throw new Error('Could not find Drafts mailbox');
+    }
+
+    // Ensure we have at least one body type
+    if (!email.textBody && !email.htmlBody) {
+      throw new Error('Either textBody or htmlBody must be provided');
+    }
+
+    const mailboxIds: Record<string, boolean> = {};
+    mailboxIds[draftsMailbox.id] = true;
+
+    const emailObject: any = {
+      mailboxIds,
+      keywords: { $draft: true },
+      from: [{ email: fromEmail }],
+      to: email.to.map(addr => ({ email: addr })),
+      cc: email.cc?.map(addr => ({ email: addr })) || [],
+      bcc: email.bcc?.map(addr => ({ email: addr })) || [],
+      subject: email.subject,
+      ...(email.inReplyTo && { inReplyTo: email.inReplyTo }),
+      ...(email.references && { references: email.references }),
+      textBody: email.textBody ? [{ partId: 'text', type: 'text/plain' }] : undefined,
+      htmlBody: email.htmlBody ? [{ partId: 'html', type: 'text/html' }] : undefined,
+      bodyValues: {
+        ...(email.textBody && { text: { value: email.textBody } }),
+        ...(email.htmlBody && { html: { value: email.htmlBody } })
+      }
+    };
+
+    const request: JmapRequest = {
+      using: ['urn:ietf:params:jmap:core', 'urn:ietf:params:jmap:mail'],
+      methodCalls: [
+        ['Email/set', {
+          accountId: session.accountId,
+          create: { draft: emailObject }
+        }, 'createDraft']
+      ]
+    };
+
+    const response = await this.makeRequest(request);
+    
+    // Check if draft creation was successful
+    const draftResult = response.methodResponses[0][1];
+    if (draftResult.notCreated && draftResult.notCreated.draft) {
+      throw new Error('Failed to create draft. Please check inputs and try again.');
+    }
+    
+    return draftResult.created?.draft?.id || 'unknown';
+  }
+
   async getRecentEmails(limit: number = 10, mailboxName: string = 'inbox'): Promise<any[]> {
     const session = await this.getSession();
     
@@ -424,6 +513,128 @@ export class JmapClient {
     
     if (result.notUpdated && result.notUpdated[emailId]) {
       throw new Error('Failed to move email.');
+    }
+  }
+
+  async addLabels(emailId: string, mailboxIds: string[]): Promise<void> {
+    const session = await this.getSession();
+
+    // Build patch object to add specific mailboxIds
+    const patch: Record<string, any> = {};
+    mailboxIds.forEach(mailboxId => {
+      patch[`mailboxIds/${mailboxId}`] = true;
+    });
+
+    const request: JmapRequest = {
+      using: ['urn:ietf:params:jmap:core', 'urn:ietf:params:jmap:mail'],
+      methodCalls: [
+        ['Email/set', {
+          accountId: session.accountId,
+          update: {
+            [emailId]: patch
+          }
+        }, 'addLabels']
+      ]
+    };
+
+    const response = await this.makeRequest(request);
+    const result = response.methodResponses[0][1];
+
+    if (result.notUpdated && result.notUpdated[emailId]) {
+      throw new Error('Failed to add labels to email.');
+    }
+  }
+
+  async removeLabels(emailId: string, mailboxIds: string[]): Promise<void> {
+    const session = await this.getSession();
+
+    // Build patch object to remove specific mailboxIds
+    const patch: Record<string, any> = {};
+    mailboxIds.forEach(mailboxId => {
+      patch[`mailboxIds/${mailboxId}`] = null;
+    });
+
+    const request: JmapRequest = {
+      using: ['urn:ietf:params:jmap:core', 'urn:ietf:params:jmap:mail'],
+      methodCalls: [
+        ['Email/set', {
+          accountId: session.accountId,
+          update: {
+            [emailId]: patch
+          }
+        }, 'removeLabels']
+      ]
+    };
+
+    const response = await this.makeRequest(request);
+    const result = response.methodResponses[0][1];
+
+    if (result.notUpdated && result.notUpdated[emailId]) {
+      throw new Error('Failed to remove labels from email.');
+    }
+  }
+
+  async bulkAddLabels(emailIds: string[], mailboxIds: string[]): Promise<void> {
+    const session = await this.getSession();
+
+    // Build patch object to add specific mailboxIds
+    const patch: Record<string, any> = {};
+    mailboxIds.forEach(mailboxId => {
+      patch[`mailboxIds/${mailboxId}`] = true;
+    });
+
+    const updates: Record<string, any> = {};
+    emailIds.forEach(id => {
+      updates[id] = patch;
+    });
+
+    const request: JmapRequest = {
+      using: ['urn:ietf:params:jmap:core', 'urn:ietf:params:jmap:mail'],
+      methodCalls: [
+        ['Email/set', {
+          accountId: session.accountId,
+          update: updates
+        }, 'bulkAddLabels']
+      ]
+    };
+
+    const response = await this.makeRequest(request);
+    const result = response.methodResponses[0][1];
+
+    if (result.notUpdated && Object.keys(result.notUpdated).length > 0) {
+      throw new Error('Failed to add labels to some emails.');
+    }
+  }
+
+  async bulkRemoveLabels(emailIds: string[], mailboxIds: string[]): Promise<void> {
+    const session = await this.getSession();
+
+    // Build patch object to remove specific mailboxIds
+    const patch: Record<string, any> = {};
+    mailboxIds.forEach(mailboxId => {
+      patch[`mailboxIds/${mailboxId}`] = null;
+    });
+
+    const updates: Record<string, any> = {};
+    emailIds.forEach(id => {
+      updates[id] = patch;
+    });
+
+    const request: JmapRequest = {
+      using: ['urn:ietf:params:jmap:core', 'urn:ietf:params:jmap:mail'],
+      methodCalls: [
+        ['Email/set', {
+          accountId: session.accountId,
+          update: updates
+        }, 'bulkRemoveLabels']
+      ]
+    };
+
+    const response = await this.makeRequest(request);
+    const result = response.methodResponses[0][1];
+
+    if (result.notUpdated && Object.keys(result.notUpdated).length > 0) {
+      throw new Error('Failed to remove labels from some emails.');
     }
   }
 


### PR DESCRIPTION
## Summary

Adds a `reply_email` tool that sends properly threaded replies by automatically setting `In-Reply-To` and `References` headers.

### Changes

- **New `reply_email` tool** — Takes an `originalEmailId`, fetches the original email's `Message-ID` and `References`, and sends a reply that threads correctly in email clients. Defaults `to` to the original sender and prepends "Re: " to the subject.
- **Enhanced `send_email`** — Added optional `inReplyTo` and `references` parameters for manual threading control.
- **Enhanced `getEmailById`** — Now fetches `messageId`, `threadId`, `inReplyTo`, and `references` properties so threading metadata is available.

### Why

Currently there's no way to reply to an email in-thread — `send_email` always creates a new conversation. This is a common need for AI assistants doing email triage and customer support.

### Testing

Tested against a live Fastmail account — replies thread correctly in both Fastmail and Gmail.