### PR TITLE
Add inReplyTo and references for email reply threading

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -216,6 +216,15 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               type: 'string',
               description: 'HTML body (optional)',
             },
+            inReplyTo: {
+              type: 'string',
+              description: 'Message-ID of the email being replied to (for threading)',
+            },
+            references: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Message-IDs for thread continuity',
+            },
           },
           required: ['to', 'subject'],
         },
@@ -701,7 +710,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'send_email': {
-        const { to, cc, bcc, from, mailboxId, subject, textBody, htmlBody } = args as any;
+        const { to, cc, bcc, from, mailboxId, subject, textBody, htmlBody, inReplyTo, references } = args as any;
         if (!to || !Array.isArray(to) || to.length === 0) {
           throw new McpError(ErrorCode.InvalidParams, 'to field is required and must be a non-empty array');
         }
@@ -721,6 +730,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           subject,
           textBody,
           htmlBody,
+          inReplyTo,
+          references,
         });
 
         return {

--- a/src/jmap-client.ts
+++ b/src/jmap-client.ts
@@ -128,7 +128,7 @@ export class JmapClient {
         ['Email/get', {
           accountId: session.accountId,
           ids: [id],
-          properties: ['id', 'subject', 'from', 'to', 'cc', 'bcc', 'receivedAt', 'textBody', 'htmlBody', 'attachments', 'bodyValues'],
+          properties: ['id', 'messageId', 'references', 'subject', 'from', 'to', 'cc', 'bcc', 'receivedAt', 'textBody', 'htmlBody', 'attachments', 'bodyValues'],
           bodyProperties: ['partId', 'blobId', 'type', 'size'],
           fetchTextBodyValues: true,
           fetchHTMLBodyValues: true,
@@ -183,6 +183,8 @@ export class JmapClient {
     htmlBody?: string;
     from?: string;
     mailboxId?: string;
+    inReplyTo?: string;      // Message-ID of email being replied to
+    references?: string[];   // Thread Message-IDs for continuity
   }): Promise<string> {
     const session = await this.getSession();
 
@@ -235,7 +237,7 @@ export class JmapClient {
     const sentMailboxIds: Record<string, boolean> = {};
     sentMailboxIds[sentMailbox.id] = true;
 
-    const emailObject = {
+    const emailObject: Record<string, any> = {
       mailboxIds: initialMailboxIds,
       keywords: { $draft: true },
       from: [{ email: fromEmail }],
@@ -250,6 +252,14 @@ export class JmapClient {
         ...(email.htmlBody && { html: { value: email.htmlBody } })
       }
     };
+
+    // Add reply headers for proper threading
+    if (email.inReplyTo) {
+      emailObject.inReplyTo = email.inReplyTo;
+    }
+    if (email.references && email.references.length > 0) {
+      emailObject.references = email.references.join(' ');
+    }
 
     const request: JmapRequest = {
       using: ['urn:ietf:params:jmap:core', 'urn:ietf:params:jmap:mail', 'urn:ietf:params:jmap:submission'],


### PR DESCRIPTION
## Summary
- Adds `inReplyTo` and `references` parameters to the `send_email` tool to enable proper email threading when replying
- Fetches `messageId` and `references` fields in `get_email` to provide data needed for constructing reply headers

## Changes
- `src/jmap-client.ts`: Extended `sendEmail` interface, added reply headers to email object, added `messageId` and `references` to fetched email properties
- `src/index.ts`: Added `inReplyTo` and `references` to tool schema and handler

## Usage
When replying to an email:
1. Use `get_email` to fetch the original email (now includes `messageId` and `references`)
2. Call `send_email` with:
   - `inReplyTo`: the original email's `messageId`
   - `references`: array containing original `references` plus the original `messageId`

This enables email clients to properly thread replies in conversations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)