### PR TITLE
fix(jmap): use patch notation for moveEmail and bulkMove

### DIFF
--- a/src/jmap-client.ts
+++ b/src/jmap-client.ts
@@ -44,7 +44,7 @@ export class JmapClient {
     
     this.session = {
       apiUrl: sessionData.apiUrl,
-      accountId: Object.keys(sessionData.accounts)[0],
+      accountId: sessionData.primaryAccounts?.['urn:ietf:params:jmap:mail'] ?? Object.keys(sessionData.accounts)[0],
       capabilities: sessionData.capabilities,
       downloadUrl: sessionData.downloadUrl,
       uploadUrl: sessionData.uploadUrl


### PR DESCRIPTION
## Problems Fixed

### 1. `moveEmail` / `bulkMove` silently fail (no-op)

Both methods updated `mailboxIds` by replacing the entire map:

```js
update: { [emailId]: { mailboxIds: { targetId: true } } }
```

This silently succeeds (no `notUpdated` error) but has **no effect** on Fastmail — emails remain in their original mailbox. Fastmail's JMAP implementation requires the **patch notation** for `mailboxIds` updates.

**Fix:** Fetch the current `mailboxIds` first, then build a patch that explicitly nulls out each existing mailbox and sets the target:

```js
{ "mailboxIds/oldId": null, "mailboxIds/targetId": true }
```

For `bulkMove`, all current `mailboxIds` are fetched in a single `Email/get` request before constructing per-email patches.

---

### 2. Wrong account selected when multiple sub-accounts exist

`getSession()` used `Object.keys(sessionData.accounts)[0]` to pick the account ID. When Fastmail returns multiple accounts (e.g. a contacts-only masteruser account alongside the primary mail account), this picks the wrong account, causing all `Mailbox/get` and `Email/*` calls to fail with:

```
accountNotSupportedByMethod: Mailbox needs data for one of 'mail' but account does not have this data group
```

**Fix:** Use `sessionData.primaryAccounts['urn:ietf:params:jmap:mail']` to resolve the correct account for mail operations, falling back to the first key for compatibility.

---

## Testing

Both fixes verified against a live Fastmail account with multiple sub-accounts.