### PR TITLE
fix(docs): use correct scoped package name for dxt CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ You can install this server as a Desktop Extension for Claude Desktop using the 
 1. Build and pack:
    ```bash
    npm run build
-   npx dxt pack
+   npx @anthropic-ai/dxt pack
    ```
    This produces `fastmail-mcp.dxt` in the project root.
 


### PR DESCRIPTION
## Summary
- `npx dxt pack` resolves to an unrelated npm package (`dxt@1.0.1`) that has no `bin` entry, causing "could not determine executable to run"
- Replace with `npx @anthropic-ai/dxt pack` to match what CI already uses in `.github/workflows/build-dxt.yml`

## Test plan
- [x] Verified `npx @anthropic-ai/dxt pack` produces `fastmail-mcp.dxt` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)