### PR TITLE
fix: use primaryAccounts to select correct JMAP account

### DIFF
--- a/src/jmap-client.ts
+++ b/src/jmap-client.ts
@@ -44,7 +44,9 @@ export class JmapClient {
     
     this.session = {
       apiUrl: sessionData.apiUrl,
-      accountId: Object.keys(sessionData.accounts)[0],
+      accountId: sessionData.primaryAccounts?.['urn:ietf:params:jmap:mail']
+        || sessionData.primaryAccounts?.['urn:ietf:params:jmap:core']
+        || Object.keys(sessionData.accounts)[0],
       capabilities: sessionData.capabilities,
       downloadUrl: sessionData.downloadUrl,
       uploadUrl: sessionData.uploadUrl


### PR DESCRIPTION
## Summary

- When a Fastmail session has multiple accounts (e.g. a contacts-only account and the main mail account), `Object.keys(accounts)[0]` can pick the wrong one
- Use `session.primaryAccounts['urn:ietf:params:jmap:mail']` to select the mail-capable account per the JMAP spec
- Falls back to `primaryAccounts['urn:ietf:params:jmap:core']`, then `Object.keys(accounts)[0]`

## Problem

Fastmail sessions can contain multiple accounts. The existing code picks the first account key alphabetically, which may be a secondary account without mail capability. This causes all mail operations (`list_mailboxes`, `list_emails`, `get_account_summary`, etc.) to fail with `accountNotSupportedByMethod` errors.

## Test plan

- [x] Verified JMAP `Mailbox/get` succeeds with the correct account ID
- [x] Tested `list_mailboxes` — returns user's mailboxes
- [x] Tested `get_account_summary` — returns full account stats
- [x] Tested `list_emails` — returns recent emails
- [x] `check_function_availability` continues to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)