### PR TITLE
chore(release): bump manifest.json version to 1.7.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "dxt_version": "0.1",
   "name": "fastmail-mcp",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "MCP server for Fastmail API integration",
   "author": {
     "name": "Jeremy Gill"


### PR DESCRIPTION
## Summary
- Bump `manifest.json` version from `1.6.1` to `1.7.0` to match `package.json` and `index.ts`
- Required for the v1.7.0 DXT release to show the correct version

https://claude.ai/code/session_01Vb8Y5T7SBbDjkRnUjunBCX