### PR TITLE
Fix path traversal vulnerability in download_attachment

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -663,7 +663,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             savePath: {
               type: 'string',
-              description: 'Absolute file path to save the attachment to. Parent directories will be created automatically.',
+              description: 'File path within ~/Downloads/fastmail-mcp/ to save the attachment to. Paths outside this directory are rejected for security. Parent directories will be created automatically.',
             },
           },
           required: ['emailId', 'attachmentId'],

--- a/src/jmap-client.test.ts
+++ b/src/jmap-client.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, beforeEach, mock } from 'node:test';
 import assert from 'node:assert/strict';
+import { homedir } from 'os';
+import { resolve } from 'path';
 import { JmapClient } from './jmap-client.js';
 import { FastmailAuth } from './auth.js';
 
@@ -218,5 +220,61 @@ describe('createDraft', () => {
     assert.deepEqual(emailObj.htmlBody, [{ partId: 'html', type: 'text/html' }]);
     assert.equal(emailObj.textBody, undefined);
     assert.deepEqual(emailObj.bodyValues, { html: { value: '<p>Hello</p>' } });
+  });
+});
+
+// ---------- validateSavePath tests ----------
+
+describe('validateSavePath', () => {
+  const allowedDir = resolve(homedir(), 'Downloads', 'fastmail-mcp');
+
+  it('accepts paths within the allowed directory', () => {
+    const result = JmapClient.validateSavePath(`${allowedDir}/photo.jpg`);
+    assert.equal(result, `${allowedDir}/photo.jpg`);
+  });
+
+  it('accepts paths in subdirectories', () => {
+    const result = JmapClient.validateSavePath(`${allowedDir}/andrew/assets/logo.png`);
+    assert.equal(result, `${allowedDir}/andrew/assets/logo.png`);
+  });
+
+  it('rejects paths outside the allowed directory', () => {
+    assert.throws(
+      () => JmapClient.validateSavePath('/tmp/evil.sh'),
+      (err: Error) => {
+        assert.match(err.message, /must be within/);
+        return true;
+      },
+    );
+  });
+
+  it('rejects path traversal attempts', () => {
+    assert.throws(
+      () => JmapClient.validateSavePath(`${allowedDir}/../../../.bashrc`),
+      (err: Error) => {
+        assert.match(err.message, /must be within/);
+        return true;
+      },
+    );
+  });
+
+  it('rejects home directory writes', () => {
+    assert.throws(
+      () => JmapClient.validateSavePath(`${homedir()}/.ssh/authorized_keys`),
+      (err: Error) => {
+        assert.match(err.message, /must be within/);
+        return true;
+      },
+    );
+  });
+
+  it('rejects null bytes', () => {
+    assert.throws(
+      () => JmapClient.validateSavePath(`${allowedDir}/file\0.txt`),
+      (err: Error) => {
+        assert.match(err.message, /null bytes/);
+        return true;
+      },
+    );
   });
 });

--- a/src/jmap-client.ts
+++ b/src/jmap-client.ts
@@ -1,6 +1,7 @@
 import { FastmailAuth } from './auth.js';
 import { writeFile, mkdir } from 'fs/promises';
-import { dirname } from 'path';
+import { dirname, resolve, normalize } from 'path';
+import { homedir } from 'os';
 
 export interface JmapSession {
   apiUrl: string;
@@ -887,7 +888,28 @@ export class JmapClient {
     return url;
   }
 
+  static readonly DEFAULT_DOWNLOADS_DIR = resolve(homedir(), 'Downloads', 'fastmail-mcp');
+
+  static validateSavePath(savePath: string): string {
+    const allowedDir = JmapClient.DEFAULT_DOWNLOADS_DIR;
+    const resolved = resolve(normalize(savePath));
+
+    if (!resolved.startsWith(allowedDir + '/') && resolved !== allowedDir) {
+      throw new Error(
+        `Save path must be within ${allowedDir}. ` +
+        `Received: ${savePath}`
+      );
+    }
+
+    if (resolved.includes('\0')) {
+      throw new Error('Save path contains null bytes');
+    }
+
+    return resolved;
+  }
+
   async downloadAttachmentToFile(emailId: string, attachmentId: string, savePath: string): Promise<{ url: string; bytesWritten: number }> {
+    const validatedPath = JmapClient.validateSavePath(savePath);
     const url = await this.downloadAttachment(emailId, attachmentId);
 
     const response = await fetch(url, {
@@ -900,8 +922,8 @@ export class JmapClient {
 
     const buffer = Buffer.from(await response.arrayBuffer());
 
-    await mkdir(dirname(savePath), { recursive: true });
-    await writeFile(savePath, buffer);
+    await mkdir(dirname(validatedPath), { recursive: true });
+    await writeFile(validatedPath, buffer);
 
     return { url, bytesWritten: buffer.length };
   }


### PR DESCRIPTION
## Summary

- `downloadAttachmentToFile()` accepts arbitrary file paths with no validation, allowing writes anywhere on the filesystem
- An AI assistant manipulated via prompt injection (e.g. malicious email content) could be tricked into writing files to sensitive locations like `~/.bashrc`, `~/.ssh/authorized_keys`, etc.
- Adds `validateSavePath()` that restricts all downloads to `~/Downloads/fastmail-mcp/` and rejects path traversal sequences, absolute paths outside the sandbox, and null byte injection
- 6 new tests covering valid paths, traversal attacks, and null bytes
- Updated tool description to inform the AI of the path restriction

## Test plan

- [x] All 16 existing + new tests pass
- [x] Valid paths within `~/Downloads/fastmail-mcp/` accepted
- [x] `../` traversal rejected
- [x] Absolute paths outside sandbox rejected
- [x] Null byte injection rejected