### PR TITLE
fix: resolve content serialization errors after SDK v1.x upgrade

### DIFF
--- a/.github/workflows/build-dxt.yml
+++ b/.github/workflows/build-dxt.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
@@ -37,7 +37,7 @@ jobs:
           echo "DXT_FILE=fastmail-mcp-$VERSION.dxt" >> $GITHUB_ENV
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: fastmail-mcp-dxt
           path: ${{ env.DXT_FILE }}

--- a/.github/workflows/npx-smoke.yml
+++ b/.github/workflows/npx-smoke.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [18, 20, 22]
+        node: [20, 22, 24]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node }}
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Pin to a tagged release:
 
 ```bash
 FASTMAIL_API_TOKEN="your_token" \
-  npx --yes github:MadLlama25/fastmail-mcp@v1.6.1 fastmail-mcp
+  npx --yes github:MadLlama25/fastmail-mcp@v1.7.1 fastmail-mcp
 ```
 
 ## Install as a Claude Desktop Extension (DXT)
@@ -283,6 +283,10 @@ Contributions are welcome! Please ensure that:
 2. **Missing Dependencies**: Run `npm install` to ensure all dependencies are installed  
 3. **Build Errors**: Check that TypeScript compilation completes without errors using `npm run build`
 4. **Calendar/Contacts "Forbidden" Errors**: Use `check_function_availability` to see setup guidance
+
+### Email Tools Failing with Serialization Errors?
+
+If `get_email`, `list_emails`, `search_emails`, or `advanced_search` fail with "content serialization" or "Cannot read properties of undefined" errors, upgrade to v1.7.1+. This was caused by incomplete JMAP response validation that surfaced after the MCP SDK v1.x upgrade added stricter result checking.
 
 ### Calendar/Contacts Not Working?
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "dxt_version": "0.1",
   "name": "fastmail-mcp",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "MCP server for Fastmail API integration",
   "author": {
     "name": "Jeremy Gill"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastmail-mcp",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "MCP server for Fastmail API integration",
   "main": "dist/index.js",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import { ContactsCalendarClient } from './contacts-calendar.js';
 const server = new Server(
   {
     name: 'fastmail-mcp',
-    version: '1.7.0',
+    version: '1.7.1',
   },
   {
     capabilities: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import {
   McpError,
 } from '@modelcontextprotocol/sdk/types.js';
 import { FastmailAuth, FastmailConfig } from './auth.js';
-import { JmapClient, JmapRequest } from './jmap-client.js';
+import { JmapClient } from './jmap-client.js';
 import { ContactsCalendarClient } from './contacts-calendar.js';
 
 const server = new Server(
@@ -1091,33 +1091,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         if (!query) {
           throw new McpError(ErrorCode.InvalidParams, 'query is required');
         }
-
-        // For search, we'll use the Email/query method with a text filter
-        const session = await client.getSession();
-        const request: JmapRequest = {
-          using: ['urn:ietf:params:jmap:core', 'urn:ietf:params:jmap:mail'],
-          methodCalls: [
-            ['Email/query', {
-              accountId: session.accountId,
-              filter: { text: query },
-              sort: [{ property: 'receivedAt', isAscending: false }],
-              limit
-            }, 'query'],
-            ['Email/get', {
-              accountId: session.accountId,
-              '#ids': { resultOf: 'query', name: 'Email/query', path: '/ids' },
-              properties: ['id', 'subject', 'from', 'to', 'receivedAt', 'preview', 'hasAttachment']
-            }, 'emails']
-          ]
-        };
-
-        const response = await client.makeRequest(request);
-        const emailResult = response.methodResponses[1];
-        if (emailResult[0] === 'error') {
-          throw new McpError(ErrorCode.InternalError, `JMAP error: ${emailResult[1].type}`);
-        }
-        const emails = emailResult[1].list || [];
-
+        const emails = await client.searchEmails(query, limit);
         return {
           content: [
             {

--- a/src/jmap-client.test.ts
+++ b/src/jmap-client.test.ts
@@ -220,3 +220,98 @@ describe('createDraft', () => {
     assert.deepEqual(emailObj.bodyValues, { html: { value: '<p>Hello</p>' } });
   });
 });
+
+describe('JMAP response validation', () => {
+  let client: JmapClient;
+
+  beforeEach(() => {
+    client = makeClient();
+  });
+
+  it('throws when methodResponses is missing', async () => {
+    stubMakeRequest(client, { sessionState: 's1' });
+    await assert.rejects(
+      () => client.getEmailById('email-1'),
+      (err: Error) => {
+        assert.match(err.message, /missing expected method/i);
+        return true;
+      },
+    );
+  });
+
+  it('throws when index exceeds methodResponses length', async () => {
+    stubMakeRequest(client, {
+      methodResponses: [
+        ['error', { type: 'serverFail', description: 'oops' }, 'query'],
+      ],
+    });
+    // getEmails uses getListResult(response, 1) but only 1 response exists
+    await assert.rejects(
+      () => client.getEmails(undefined, 10),
+      (err: Error) => {
+        assert.ok(err.message.length > 0);
+        return true;
+      },
+    );
+  });
+
+  it('throws on malformed methodResponses entry', async () => {
+    stubMakeRequest(client, {
+      methodResponses: ['not-a-tuple' as any],
+    });
+    await assert.rejects(
+      () => client.getEmailById('email-1'),
+      (err: Error) => {
+        assert.match(err.message, /malformed/i);
+        return true;
+      },
+    );
+  });
+});
+
+describe('searchEmails', () => {
+  let client: JmapClient;
+
+  beforeEach(() => {
+    client = makeClient();
+  });
+
+  it('returns email list on success', async () => {
+    stubMakeRequest(client, {
+      methodResponses: [
+        ['Email/query', { ids: ['e1'] }, 'query'],
+        ['Email/get', { list: [{ id: 'e1', subject: 'Test' }] }, 'emails'],
+      ],
+    });
+    const results = await client.searchEmails('test', 10);
+    assert.equal(results.length, 1);
+    assert.equal(results[0].subject, 'Test');
+  });
+
+  it('returns empty array when no results', async () => {
+    stubMakeRequest(client, {
+      methodResponses: [
+        ['Email/query', { ids: [] }, 'query'],
+        ['Email/get', { list: [] }, 'emails'],
+      ],
+    });
+    const results = await client.searchEmails('nonexistent');
+    assert.deepEqual(results, []);
+  });
+
+  it('throws on JMAP error in query', async () => {
+    stubMakeRequest(client, {
+      methodResponses: [
+        ['error', { type: 'invalidArguments', description: 'bad filter' }, 'query'],
+        ['error', { type: 'invalidArguments', description: 'bad filter' }, 'emails'],
+      ],
+    });
+    await assert.rejects(
+      () => client.searchEmails('test'),
+      (err: Error) => {
+        assert.match(err.message, /invalidArguments/);
+        return true;
+      },
+    );
+  });
+});

--- a/src/jmap-client.ts
+++ b/src/jmap-client.ts
@@ -32,7 +32,16 @@ export class JmapClient {
    * Extract the result from a JMAP method response, throwing on method-level errors.
    */
   protected getMethodResult(response: JmapResponse, index: number): any {
-    const [tag, result] = response.methodResponses[index];
+    if (!response.methodResponses || index >= response.methodResponses.length) {
+      throw new Error(
+        `JMAP response missing expected method at index ${index} (got ${response.methodResponses?.length ?? 0} responses)`
+      );
+    }
+    const entry = response.methodResponses[index];
+    if (!Array.isArray(entry) || entry.length < 2) {
+      throw new Error(`JMAP response entry at index ${index} is malformed`);
+    }
+    const [tag, result] = entry;
     if (tag === 'error') {
       throw new Error(`JMAP error: ${result.type}${result.description ? ' - ' + result.description : ''}`);
     }
@@ -99,7 +108,11 @@ export class JmapClient {
       throw new Error(`JMAP request failed: ${response.statusText}`);
     }
 
-    return await response.json() as JmapResponse;
+    const data = await response.json();
+    if (!data || !Array.isArray(data.methodResponses)) {
+      throw new Error('Invalid JMAP response: missing or malformed methodResponses');
+    }
+    return data as JmapResponse;
   }
 
   async getMailboxes(): Promise<any[]> {
@@ -309,13 +322,7 @@ export class JmapClient {
 
     const response = await this.makeRequest(request);
 
-    // Check for JMAP method-level error on Email/set
-    if (response.methodResponses[0][0] === 'error') {
-      const err = response.methodResponses[0][1];
-      throw new Error(`JMAP error creating email: ${err.type}${err.description ? ' - ' + err.description : ''}`);
-    }
-
-    const emailResult = response.methodResponses[0][1];
+    const emailResult = this.getMethodResult(response, 0);
     if (emailResult.notCreated?.draft) {
       const err = emailResult.notCreated.draft;
       throw new Error(`Failed to create email: ${err.type}${err.description ? ' - ' + err.description : ''}`);
@@ -326,13 +333,7 @@ export class JmapClient {
       throw new Error('Email creation returned no email ID');
     }
 
-    // Check for JMAP method-level error on EmailSubmission/set
-    if (response.methodResponses[1][0] === 'error') {
-      const err = response.methodResponses[1][1];
-      throw new Error(`JMAP error submitting email: ${err.type}${err.description ? ' - ' + err.description : ''}`);
-    }
-
-    const submissionResult = response.methodResponses[1][1];
+    const submissionResult = this.getMethodResult(response, 1);
     if (submissionResult.notCreated?.submission) {
       const err = submissionResult.notCreated.submission;
       throw new Error(`Failed to submit email: ${err.type}${err.description ? ' - ' + err.description : ''}`);
@@ -430,13 +431,7 @@ export class JmapClient {
 
     const response = await this.makeRequest(request);
 
-    // Bug 1: Check for JMAP method-level error
-    if (response.methodResponses[0][0] === 'error') {
-      const err = response.methodResponses[0][1];
-      throw new Error(`JMAP error: ${err.type}${err.description ? ' - ' + err.description : ''}`);
-    }
-
-    const result = response.methodResponses[0][1];
+    const result = this.getMethodResult(response, 0);
 
     // Bug 2: Propagate server-provided error details from notCreated
     if (result.notCreated?.draft) {
@@ -603,7 +598,7 @@ export class JmapClient {
     };
 
     const response = await this.makeRequest(request);
-    const result = response.methodResponses[0][1];
+    const result = this.getMethodResult(response, 0);
     
     if (result.notUpdated && result.notUpdated[emailId]) {
       throw new Error(`Failed to mark email as ${read ? 'read' : 'unread'}.`);
@@ -639,7 +634,7 @@ export class JmapClient {
     };
 
     const response = await this.makeRequest(request);
-    const result = response.methodResponses[0][1];
+    const result = this.getMethodResult(response, 0);
     
     if (result.notUpdated && result.notUpdated[emailId]) {
       throw new Error('Failed to delete email.');
@@ -685,7 +680,7 @@ export class JmapClient {
     };
 
     const response = await this.makeRequest(request);
-    const result = response.methodResponses[0][1];
+    const result = this.getMethodResult(response, 0);
 
     if (result.notUpdated && result.notUpdated[emailId]) {
       throw new Error('Failed to move email.');
@@ -714,7 +709,7 @@ export class JmapClient {
     };
 
     const response = await this.makeRequest(request);
-    const result = response.methodResponses[0][1];
+    const result = this.getMethodResult(response, 0);
 
     if (result.notUpdated && result.notUpdated[emailId]) {
       throw new Error('Failed to add labels to email.');
@@ -743,7 +738,7 @@ export class JmapClient {
     };
 
     const response = await this.makeRequest(request);
-    const result = response.methodResponses[0][1];
+    const result = this.getMethodResult(response, 0);
 
     if (result.notUpdated && result.notUpdated[emailId]) {
       throw new Error('Failed to remove labels from email.');
@@ -775,7 +770,7 @@ export class JmapClient {
     };
 
     const response = await this.makeRequest(request);
-    const result = response.methodResponses[0][1];
+    const result = this.getMethodResult(response, 0);
 
     if (result.notUpdated && Object.keys(result.notUpdated).length > 0) {
       throw new Error('Failed to add labels to some emails.');
@@ -807,7 +802,7 @@ export class JmapClient {
     };
 
     const response = await this.makeRequest(request);
-    const result = response.methodResponses[0][1];
+    const result = this.getMethodResult(response, 0);
 
     if (result.notUpdated && Object.keys(result.notUpdated).length > 0) {
       throw new Error('Failed to remove labels from some emails.');
@@ -960,6 +955,30 @@ export class JmapClient {
     return this.getListResult(response, 1);
   }
 
+  async searchEmails(query: string, limit: number = 20): Promise<any[]> {
+    const session = await this.getSession();
+
+    const request: JmapRequest = {
+      using: ['urn:ietf:params:jmap:core', 'urn:ietf:params:jmap:mail'],
+      methodCalls: [
+        ['Email/query', {
+          accountId: session.accountId,
+          filter: { text: query },
+          sort: [{ property: 'receivedAt', isAscending: false }],
+          limit
+        }, 'query'],
+        ['Email/get', {
+          accountId: session.accountId,
+          '#ids': { resultOf: 'query', name: 'Email/query', path: '/ids' },
+          properties: ['id', 'subject', 'from', 'to', 'receivedAt', 'preview', 'hasAttachment']
+        }, 'emails']
+      ]
+    };
+
+    const response = await this.makeRequest(request);
+    return this.getListResult(response, 1);
+  }
+
   async getThread(threadId: string): Promise<any[]> {
     const session = await this.getSession();
 
@@ -1098,7 +1117,7 @@ export class JmapClient {
     };
 
     const response = await this.makeRequest(request);
-    const result = response.methodResponses[0][1];
+    const result = this.getMethodResult(response, 0);
     
     if (result.notUpdated && Object.keys(result.notUpdated).length > 0) {
       throw new Error('Failed to update some emails.');
@@ -1146,7 +1165,7 @@ export class JmapClient {
     };
 
     const response = await this.makeRequest(request);
-    const result = response.methodResponses[0][1];
+    const result = this.getMethodResult(response, 0);
 
     if (result.notUpdated && Object.keys(result.notUpdated).length > 0) {
       throw new Error('Failed to move some emails.');
@@ -1183,7 +1202,7 @@ export class JmapClient {
     };
 
     const response = await this.makeRequest(request);
-    const result = response.methodResponses[0][1];
+    const result = this.getMethodResult(response, 0);
 
     if (result.notUpdated && Object.keys(result.notUpdated).length > 0) {
       throw new Error('Failed to delete some emails.');


### PR DESCRIPTION
## Summary

- Harden JMAP response validation in `makeRequest` and `getMethodResult` to prevent crashes from malformed API responses
- Migrate all 19 direct `response.methodResponses[N]` accesses to use safe `getMethodResult` helper with bounds/error checking
- Extract inline JMAP code from `search_emails` handler into new `JmapClient.searchEmails()` method
- Add 6 new unit tests covering response validation edge cases and the new `searchEmails` method
- Bump version to v1.7.1 with updated documentation and troubleshooting guidance
- Bump GitHub Actions to v5 (Node.js 24 runtime) and update CI node matrix

Fixes #25

## Root Cause

After upgrading MCP SDK from v0.6.0 to v1.27.1, the SDK now validates all tool call results via `safeParse()`. The response format was correct, but unvalidated JMAP responses and unsafe direct array accesses caused crashes that propagated as confusing SDK validation errors.

## Test plan

- [x] All 16 unit tests pass (`npm test`)
- [x] Clean TypeScript build (`npm run build`)
- [x] DXT package built successfully
- [x] Manual testing with Fastmail API (requires live API token)