### PR TITLE
fix: remove dead code, add input guards, and fix double parseInt

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,17 +26,6 @@ const server = new Server(
 let jmapClient: JmapClient | null = null;
 let contactsCalendarClient: ContactsCalendarClient | null = null;
 
-function resolveEnvValue(...keys: string[]): string | undefined {
-  const isPlaceholder = (val: string) => /\$\{[^}]+\}/.test(val.trim());
-  for (const key of keys) {
-    const raw = process.env[key];
-    if (typeof raw === 'string' && raw.trim().length > 0 && !isPlaceholder(raw)) {
-      return raw.trim();
-    }
-  }
-  return undefined;
-}
-
 function findEnvValue(keys: string[]): { value?: string; key?: string; wasPlaceholder: boolean } {
   const isPlaceholder = (val: string) => /\$\{[^}]+\}/.test(val.trim());
   for (const key of keys) {
@@ -900,8 +889,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'list_emails': {
-        const { mailboxId, limit = 20 } = args as any;
-        const emails = await client.getEmails(mailboxId, limit);
+        const { mailboxId, limit } = args as any;
+        const validLimit = Math.min(Math.max(Number(limit) || 20, 1), 50);
+        const emails = await client.getEmails(mailboxId, validLimit);
         return {
           content: [
             {
@@ -996,7 +986,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         // Default recipients to the original sender
         const replyTo = (to && Array.isArray(to) && to.length > 0)
           ? to
-          : originalEmail.from?.map((addr: any) => addr.email).filter(Boolean) || [];
+          : (Array.isArray(originalEmail.from) ? originalEmail.from.map((addr: any) => addr.email).filter(Boolean) : []);
 
         if (replyTo.length === 0) {
           throw new McpError(ErrorCode.InvalidParams, 'Could not determine reply recipient. Please provide "to" explicitly.');

--- a/src/jmap-client.ts
+++ b/src/jmap-client.ts
@@ -857,9 +857,11 @@ export class JmapClient {
     );
 
     // If not found, try by array index
-    if (!attachment && !isNaN(parseInt(attachmentId))) {
-      const index = parseInt(attachmentId);
-      attachment = email.attachments?.[index];
+    if (!attachment) {
+      const index = parseInt(attachmentId, 10);
+      if (!isNaN(index)) {
+        attachment = email.attachments?.[index];
+      }
     }
     
     if (!attachment) {


### PR DESCRIPTION
## Summary

Four small bug fixes and code quality improvements:

- **Remove dead code `resolveEnvValue()`** — This function in `src/index.ts` was defined but never called anywhere; `findEnvValue()` is used instead. Removed to reduce confusion.

- **Add `Array.isArray` guard in `reply_email` handler** — `originalEmail.from` could be `undefined` or a non-array value. The existing optional chaining (`?.map()`) does not protect against non-array truthy values. Added an explicit `Array.isArray()` check before calling `.map()`.

- **Avoid double `parseInt` in `downloadAttachment`** — In `src/jmap-client.ts`, `parseInt(attachmentId)` was called twice (once in the condition, once for the variable). Refactored to parse once and reuse the result.

- **Add limit validation in `list_emails` handler** — The `limit` parameter was passed directly to the JMAP query without bounds checking. Added `Math.min(Math.max(Number(limit) || 20, 1), 50)` to clamp it between 1 and 50.

## Test plan

- [x] `npm run build` compiles without errors
- [x] `npm test` — all 16 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)