### PR TITLE
refactor: extract mailbox lookup helper and shared auth config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -56,18 +56,13 @@ function maskSecret(value: string): string {
   return `${value.slice(0, 4)}…${value.slice(-2)} (len ${value.length})`;
 }
 
-function initializeClient(): JmapClient {
-  if (jmapClient) {
-    return jmapClient;
-  }
-
+function getAuthConfig(): FastmailConfig {
   const tokenInfo = findEnvValue([
     'FASTMAIL_API_TOKEN',
     'USER_CONFIG_FASTMAIL_API_TOKEN',
     'USER_CONFIG_fastmail_api_token',
     'fastmail_api_token',
   ]);
-  // production: do not log token-related env details
   const apiToken = tokenInfo.value;
   if (!apiToken) {
     throw new McpError(
@@ -82,14 +77,16 @@ function initializeClient(): JmapClient {
     'USER_CONFIG_fastmail_base_url',
     'fastmail_base_url',
   ]);
-  // production: do not log base URL env details
 
-  const config: FastmailConfig = {
-    apiToken,
-    baseUrl: baseInfo.value
-  };
+  return { apiToken, baseUrl: baseInfo.value };
+}
 
-  const auth = new FastmailAuth(config);
+function initializeClient(): JmapClient {
+  if (jmapClient) {
+    return jmapClient;
+  }
+
+  const auth = new FastmailAuth(getAuthConfig());
   jmapClient = new JmapClient(auth);
   return jmapClient;
 }
@@ -99,35 +96,7 @@ function initializeContactsCalendarClient(): ContactsCalendarClient {
     return contactsCalendarClient;
   }
 
-  const tokenInfo = findEnvValue([
-    'FASTMAIL_API_TOKEN',
-    'USER_CONFIG_FASTMAIL_API_TOKEN',
-    'USER_CONFIG_fastmail_api_token',
-    'fastmail_api_token',
-  ]);
-  // production: do not log token-related env details (contacts/calendar)
-  const apiToken = tokenInfo.value;
-  if (!apiToken) {
-    throw new McpError(
-      ErrorCode.InvalidRequest,
-      'FASTMAIL_API_TOKEN environment variable is required'
-    );
-  }
-
-  const baseInfo = findEnvValue([
-    'FASTMAIL_BASE_URL',
-    'USER_CONFIG_FASTMAIL_BASE_URL',
-    'USER_CONFIG_fastmail_base_url',
-    'fastmail_base_url',
-  ]);
-  // production: do not log base URL env details (contacts/calendar)
-
-  const config: FastmailConfig = {
-    apiToken,
-    baseUrl: baseInfo.value
-  };
-
-  const auth = new FastmailAuth(config);
+  const auth = new FastmailAuth(getAuthConfig());
   contactsCalendarClient = new ContactsCalendarClient(auth);
   return contactsCalendarClient;
 }

--- a/src/jmap-client.ts
+++ b/src/jmap-client.ts
@@ -115,6 +115,11 @@ export class JmapClient {
     return data as JmapResponse;
   }
 
+  protected findMailboxByRoleOrName(mailboxes: any[], role: string, nameFallback?: string): any | undefined {
+    return mailboxes.find(mb => mb.role === role) ||
+           (nameFallback ? mailboxes.find(mb => mb.name.toLowerCase().includes(nameFallback)) : undefined);
+  }
+
   async getMailboxes(): Promise<any[]> {
     const session = await this.getSession();
     
@@ -249,9 +254,9 @@ export class JmapClient {
 
     // Get the mailbox IDs we need
     const mailboxes = await this.getMailboxes();
-    const draftsMailbox = mailboxes.find(mb => mb.role === 'drafts') || mailboxes.find(mb => mb.name.toLowerCase().includes('draft'));
-    const sentMailbox = mailboxes.find(mb => mb.role === 'sent') || mailboxes.find(mb => mb.name.toLowerCase().includes('sent'));
-    
+    const draftsMailbox = this.findMailboxByRoleOrName(mailboxes, 'drafts', 'draft');
+    const sentMailbox = this.findMailboxByRoleOrName(mailboxes, 'sent', 'sent');
+
     if (!draftsMailbox) {
       throw new Error('Could not find Drafts mailbox to save email');
     }
@@ -390,7 +395,7 @@ export class JmapClient {
       draftMailboxId = email.mailboxId;
     } else {
       const mailboxes = await this.getMailboxes();
-      const draftsMailbox = mailboxes.find(mb => mb.role === 'drafts') || mailboxes.find(mb => mb.name.toLowerCase().includes('draft'));
+      const draftsMailbox = this.findMailboxByRoleOrName(mailboxes, 'drafts', 'draft');
       if (!draftsMailbox) {
         throw new Error('Could not find Drafts mailbox');
       }
@@ -484,8 +489,8 @@ export class JmapClient {
 
     // Get the Drafts mailbox
     const mailboxes = await this.getMailboxes();
-    const draftsMailbox = mailboxes.find(mb => mb.role === 'drafts') || mailboxes.find(mb => mb.name.toLowerCase().includes('draft'));
-    
+    const draftsMailbox = this.findMailboxByRoleOrName(mailboxes, 'drafts', 'draft');
+
     if (!draftsMailbox) {
       throw new Error('Could not find Drafts mailbox');
     }
@@ -610,8 +615,8 @@ export class JmapClient {
     
     // Find the trash mailbox
     const mailboxes = await this.getMailboxes();
-    const trashMailbox = mailboxes.find(mb => mb.role === 'trash') || mailboxes.find(mb => mb.name.toLowerCase().includes('trash'));
-    
+    const trashMailbox = this.findMailboxByRoleOrName(mailboxes, 'trash', 'trash');
+
     if (!trashMailbox) {
       throw new Error('Could not find Trash mailbox');
     }
@@ -1177,7 +1182,7 @@ export class JmapClient {
 
     // Find the trash mailbox
     const mailboxes = await this.getMailboxes();
-    const trashMailbox = mailboxes.find(mb => mb.role === 'trash') || mailboxes.find(mb => mb.name.toLowerCase().includes('trash'));
+    const trashMailbox = this.findMailboxByRoleOrName(mailboxes, 'trash', 'trash');
 
     if (!trashMailbox) {
       throw new Error('Could not find Trash mailbox');


### PR DESCRIPTION
## Summary

- **Extract `findMailboxByRoleOrName()` helper in `JmapClient`**: The pattern `mailboxes.find(mb => mb.role === 'x') || mailboxes.find(mb => mb.name.toLowerCase().includes('x'))` was duplicated across `sendEmail`, `createDraft`, `saveDraft`, `deleteEmail`, and `bulkDelete`. Replaced all 6 occurrences with a single protected method that accepts role and optional name fallback.

- **Extract `getAuthConfig()` helper in `index.ts`**: `initializeClient()` and `initializeContactsCalendarClient()` contained identical token resolution and config creation logic (~20 lines each). Extracted into a shared `getAuthConfig()` function, reducing each init function to 3-4 lines while preserving the singleton caching pattern.

## Test plan

- [x] `npm run build` compiles without errors
- [x] `npm test` passes all 16 tests
- [x] Verify mailbox lookup behavior is unchanged (drafts, sent, trash fallbacks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)