### PR TITLE
feat: add CalDAV fallback for calendar tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,26 @@ The server uses bearer token authentication with Fastmail's API. API tokens prov
 ### Rate Limits
 Fastmail applies rate limits to API requests. The server handles standard rate limiting, but excessive requests may be throttled.
 
+## CalDAV Calendar Support
+
+Fastmail does not currently expose calendar access via JMAP API tokens — the `urn:ietf:params:jmap:calendars` scope is not available because the JMAP Calendars specification is still an IETF Internet-Draft ([draft-ietf-jmap-calendars](https://datatracker.ietf.org/doc/draft-ietf-jmap-calendars/)). Fastmail has stated they will add JMAP calendar support once the spec becomes an RFC, but there is no public timeline.
+
+However, Fastmail fully supports **CalDAV** for calendar access via `caldav.fastmail.com`. This server automatically falls back to CalDAV when JMAP calendar access is unavailable.
+
+### Setup
+
+1. Create an app-specific password on Fastmail:
+   - Go to **Settings → Privacy & Security → Manage app passwords**
+   - Create a new app password (you can name it "CalDAV MCP" or similar)
+
+2. Set the following environment variables:
+   ```bash
+   export FASTMAIL_CALDAV_USERNAME="your-email@fastmail.com"
+   export FASTMAIL_CALDAV_PASSWORD="your-app-specific-password"
+   ```
+
+When these variables are set, the calendar tools (`list_calendars`, `list_calendar_events`, `get_calendar_event`, `create_calendar_event`) will automatically fall back to CalDAV if JMAP calendars are not available. When these variables are not set, the server behaves exactly as before (JMAP only).
+
 ## Development
 
 ### Project Structure
@@ -250,7 +270,8 @@ src/
 ├── index.ts              # Main MCP server implementation
 ├── auth.ts              # Authentication handling
 ├── jmap-client.ts       # JMAP client wrapper
-└── contacts-calendar.ts # Contacts and calendar extensions
+├── contacts-calendar.ts # Contacts and calendar extensions
+└── caldav-client.ts     # CalDAV calendar client (fallback)
 ```
 
 ### Building

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "fastmail-mcp",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fastmail-mcp",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.27.1"
+        "@modelcontextprotocol/sdk": "^1.27.1",
+        "tsdav": "^2.1.8"
       },
       "bin": {
         "fastmail-mcp": "dist/index.js"
@@ -573,6 +574,12 @@
         }
       }
     },
+    "node_modules/base-64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -690,6 +697,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -1273,6 +1289,26 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -1445,6 +1481,15 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
@@ -1607,6 +1652,27 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/tsdav": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/tsdav/-/tsdav-2.1.8.tgz",
+      "integrity": "sha512-zvQvhZLzTaEmNNgJbBlUYT/JOq9Xpw/xkxCqs7IT2d2/7o7pss0iZOlZXuHJ5VcvSvTny42Vc6+6GyzZcrCJ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "base-64": "1.0.0",
+        "cross-fetch": "4.1.0",
+        "debug": "4.4.3",
+        "xml-js": "1.6.11"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tsx": {
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
@@ -1680,6 +1746,22 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -1700,6 +1782,18 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "xml-js": "bin/cli.js"
+      }
     },
     "node_modules/zod": {
       "version": "3.25.76",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "author": "Jeremy Gill",
   "license": "MIT",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.27.1"
+    "@modelcontextprotocol/sdk": "^1.27.1",
+    "tsdav": "^2.1.8"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/src/caldav-client.test.ts
+++ b/src/caldav-client.test.ts
@@ -1,0 +1,225 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  extractVEvent,
+  parseICalValue,
+  formatICalDate,
+  parseCalendarObject,
+} from './caldav-client.js';
+
+describe('extractVEvent', () => {
+  it('extracts VEVENT block from iCalendar data', () => {
+    const ical = [
+      'BEGIN:VCALENDAR',
+      'BEGIN:VTIMEZONE',
+      'TZID:Europe/Rome',
+      'DTSTART:19700101T000000',
+      'END:VTIMEZONE',
+      'BEGIN:VEVENT',
+      'SUMMARY:Test Event',
+      'DTSTART;TZID=Europe/Rome:20260320T083000',
+      'END:VEVENT',
+      'END:VCALENDAR',
+    ].join('\n');
+
+    const vevent = extractVEvent(ical);
+    assert.ok(vevent.includes('SUMMARY:Test Event'));
+    assert.ok(vevent.includes('DTSTART;TZID=Europe/Rome:20260320T083000'));
+    assert.ok(!vevent.includes('VTIMEZONE'));
+    assert.ok(!vevent.includes('TZID:Europe/Rome'));
+  });
+
+  it('returns original data when no VEVENT block found', () => {
+    const data = 'no vevent here';
+    assert.equal(extractVEvent(data), data);
+  });
+
+  it('ignores VTIMEZONE DTSTART when extracting VEVENT', () => {
+    const ical = [
+      'BEGIN:VCALENDAR',
+      'BEGIN:VTIMEZONE',
+      'TZID:Europe/Rome',
+      'BEGIN:STANDARD',
+      'DTSTART:19701025T030000',
+      'RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU',
+      'END:STANDARD',
+      'END:VTIMEZONE',
+      'BEGIN:VEVENT',
+      'DTSTART;TZID=Europe/Rome:20260320T083000',
+      'SUMMARY:Meeting',
+      'END:VEVENT',
+      'END:VCALENDAR',
+    ].join('\n');
+
+    const vevent = extractVEvent(ical);
+    // Should only have the VEVENT DTSTART, not the VTIMEZONE one
+    const dtstartMatches = vevent.match(/DTSTART/g);
+    assert.equal(dtstartMatches?.length, 1);
+    assert.ok(vevent.includes('20260320T083000'));
+  });
+});
+
+describe('parseICalValue', () => {
+  it('handles simple KEY:value format', () => {
+    const vevent = 'SUMMARY:Test Event\nDTSTART:20260320T083000Z';
+    assert.equal(parseICalValue(vevent, 'SUMMARY'), 'Test Event');
+    assert.equal(parseICalValue(vevent, 'DTSTART'), '20260320T083000Z');
+  });
+
+  it('handles parameterized KEY;TZID=...:value format', () => {
+    const vevent = 'DTSTART;TZID=Europe/Rome:20260320T083000\nSUMMARY:Test';
+    assert.equal(parseICalValue(vevent, 'DTSTART'), '20260320T083000');
+  });
+
+  it('handles VALUE=DATE format', () => {
+    const vevent = 'DTSTART;VALUE=DATE:20260324\nDTEND;VALUE=DATE:20260325';
+    assert.equal(parseICalValue(vevent, 'DTSTART'), '20260324');
+    assert.equal(parseICalValue(vevent, 'DTEND'), '20260325');
+  });
+
+  it('returns undefined for missing keys', () => {
+    const vevent = 'SUMMARY:Test';
+    assert.equal(parseICalValue(vevent, 'LOCATION'), undefined);
+  });
+
+  it('handles line folding (continuation lines)', () => {
+    const vevent = 'DESCRIPTION:This is a long\n description that wraps\nSUMMARY:Test';
+    assert.equal(parseICalValue(vevent, 'DESCRIPTION'), 'This is a longdescription that wraps');
+  });
+});
+
+describe('formatICalDate', () => {
+  it('formats datetime without timezone', () => {
+    assert.equal(formatICalDate('20260320T083000'), '2026-03-20T08:30:00');
+  });
+
+  it('formats datetime with Z suffix', () => {
+    assert.equal(formatICalDate('20260320T083000Z'), '2026-03-20T08:30:00Z');
+  });
+
+  it('formats all-day date', () => {
+    assert.equal(formatICalDate('20260324'), '2026-03-24');
+  });
+
+  it('returns undefined for undefined input', () => {
+    assert.equal(formatICalDate(undefined), undefined);
+  });
+
+  it('returns cleaned string for unrecognized formats', () => {
+    assert.equal(formatICalDate('something-else'), 'something-else');
+  });
+
+  it('strips carriage returns', () => {
+    assert.equal(formatICalDate('20260320T083000\r'), '2026-03-20T08:30:00');
+  });
+});
+
+describe('parseCalendarObject', () => {
+  it('parses a full calendar object with VTIMEZONE + VEVENT', () => {
+    const data = [
+      'BEGIN:VCALENDAR',
+      'VERSION:2.0',
+      'BEGIN:VTIMEZONE',
+      'TZID:Europe/Rome',
+      'BEGIN:STANDARD',
+      'DTSTART:19701025T030000',
+      'RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU',
+      'TZOFFSETFROM:+0200',
+      'TZOFFSETTO:+0100',
+      'END:STANDARD',
+      'BEGIN:DAYLIGHT',
+      'DTSTART:19700329T020000',
+      'RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU',
+      'TZOFFSETFROM:+0100',
+      'TZOFFSETTO:+0200',
+      'END:DAYLIGHT',
+      'END:VTIMEZONE',
+      'BEGIN:VEVENT',
+      'UID:abc123@fastmail',
+      'DTSTART;TZID=Europe/Rome:20260320T083000',
+      'DTEND;TZID=Europe/Rome:20260320T093000',
+      'SUMMARY:Morning Meeting',
+      'DESCRIPTION:Discuss project\\nSecond line',
+      'LOCATION:Room A\\, Building 1',
+      'END:VEVENT',
+      'END:VCALENDAR',
+    ].join('\r\n');
+
+    const event = parseCalendarObject({ data, url: 'https://caldav.example.com/cal/abc.ics' });
+
+    assert.equal(event.id, 'abc123@fastmail');
+    assert.equal(event.url, 'https://caldav.example.com/cal/abc.ics');
+    assert.equal(event.title, 'Morning Meeting');
+    assert.equal(event.description, 'Discuss project\nSecond line');
+    assert.equal(event.location, 'Room A, Building 1');
+    // Should get the VEVENT DTSTART, not the VTIMEZONE one
+    assert.equal(event.start, '2026-03-20T08:30:00');
+    assert.equal(event.end, '2026-03-20T09:30:00');
+  });
+
+  it('parses an all-day event', () => {
+    const data = [
+      'BEGIN:VCALENDAR',
+      'BEGIN:VEVENT',
+      'UID:allday1@fastmail',
+      'DTSTART;VALUE=DATE:20260324',
+      'DTEND;VALUE=DATE:20260325',
+      'SUMMARY:All Day Event',
+      'END:VEVENT',
+      'END:VCALENDAR',
+    ].join('\r\n');
+
+    const event = parseCalendarObject({ data, url: '' });
+    assert.equal(event.start, '2026-03-24');
+    assert.equal(event.end, '2026-03-25');
+    assert.equal(event.title, 'All Day Event');
+  });
+
+  it('parses a UTC event', () => {
+    const data = [
+      'BEGIN:VCALENDAR',
+      'BEGIN:VEVENT',
+      'UID:utc1@fastmail',
+      'DTSTART:20260320T083000Z',
+      'DTEND:20260320T093000Z',
+      'SUMMARY:UTC Event',
+      'END:VEVENT',
+      'END:VCALENDAR',
+    ].join('\r\n');
+
+    const event = parseCalendarObject({ data, url: '' });
+    assert.equal(event.start, '2026-03-20T08:30:00Z');
+    assert.equal(event.end, '2026-03-20T09:30:00Z');
+  });
+
+  it('defaults title to Untitled when SUMMARY is missing', () => {
+    const data = [
+      'BEGIN:VCALENDAR',
+      'BEGIN:VEVENT',
+      'UID:notitle@fastmail',
+      'DTSTART:20260320T083000Z',
+      'END:VEVENT',
+      'END:VCALENDAR',
+    ].join('\r\n');
+
+    const event = parseCalendarObject({ data, url: '' });
+    assert.equal(event.title, 'Untitled');
+  });
+
+  it('handles missing optional fields', () => {
+    const data = [
+      'BEGIN:VCALENDAR',
+      'BEGIN:VEVENT',
+      'UID:minimal@fastmail',
+      'DTSTART:20260320T083000Z',
+      'SUMMARY:Minimal',
+      'END:VEVENT',
+      'END:VCALENDAR',
+    ].join('\r\n');
+
+    const event = parseCalendarObject({ data, url: '' });
+    assert.equal(event.description, undefined);
+    assert.equal(event.location, undefined);
+    assert.equal(event.end, undefined);
+  });
+});

--- a/src/caldav-client.ts
+++ b/src/caldav-client.ts
@@ -1,0 +1,253 @@
+import { DAVClient, DAVCalendar, DAVCalendarObject } from 'tsdav';
+
+export interface CalDAVConfig {
+  username: string;
+  password: string;
+  serverUrl?: string;
+}
+
+export interface CalendarInfo {
+  id: string;
+  displayName: string;
+  url: string;
+  description?: string;
+  color?: string;
+}
+
+export interface CalendarEvent {
+  id: string;
+  url: string;
+  title: string;
+  description?: string;
+  start?: string;
+  end?: string;
+  location?: string;
+}
+
+/**
+ * Extract the VEVENT block from iCalendar data.
+ * This avoids matching properties from VTIMEZONE or other components.
+ */
+export function extractVEvent(data: string): string {
+  const match = data.match(/BEGIN:VEVENT[\s\S]*?END:VEVENT/);
+  return match ? match[0] : data;
+}
+
+/**
+ * Parse an iCalendar property value from within a VEVENT block.
+ * Handles simple (KEY:value), parameterized (KEY;TZID=...:value),
+ * and VALUE=DATE (KEY;VALUE=DATE:20260319) forms.
+ * Also handles line folding (continuation lines starting with space/tab).
+ */
+export function parseICalValue(vevent: string, key: string): string | undefined {
+  // Match KEY followed by either ; (params) or : (value), capturing the rest
+  const regex = new RegExp(`^(${key}[;:].*)$`, 'm');
+  const match = vevent.match(regex);
+  if (!match) return undefined;
+
+  // Handle line folding: continuation lines start with space or tab
+  let fullLine = match[1];
+  const lines = vevent.split(/\r?\n/);
+  const matchIdx = lines.findIndex(l => l === fullLine || l.startsWith(fullLine));
+  if (matchIdx >= 0) {
+    for (let i = matchIdx + 1; i < lines.length; i++) {
+      if (lines[i].startsWith(' ') || lines[i].startsWith('\t')) {
+        fullLine += lines[i].substring(1);
+      } else {
+        break;
+      }
+    }
+  }
+
+  // Extract the value after the last colon in the property line
+  // For DTSTART;TZID=Europe/Rome:20260320T083000 → 20260320T083000
+  // For DTSTART:20220210T154500Z → 20220210T154500Z
+  // For DTSTART;VALUE=DATE:20260324 → 20260324
+  const colonIdx = fullLine.indexOf(':');
+  if (colonIdx === -1) return undefined;
+  return fullLine.substring(colonIdx + 1).trim();
+}
+
+/**
+ * Format an iCalendar date/datetime string to ISO 8601.
+ * Input formats: 20260320T083000, 20260320T083000Z, 20260324
+ * Output: 2026-03-20T08:30:00, 2026-03-20T08:30:00Z, 2026-03-24
+ */
+export function formatICalDate(raw: string | undefined): string | undefined {
+  if (!raw) return undefined;
+  const cleaned = raw.replace(/\r/g, '');
+
+  // All-day date: 20260324 (8 digits)
+  if (/^\d{8}$/.test(cleaned)) {
+    return `${cleaned.slice(0, 4)}-${cleaned.slice(4, 6)}-${cleaned.slice(6, 8)}`;
+  }
+
+  // DateTime: 20260320T083000 or 20260320T083000Z
+  const dtMatch = cleaned.match(/^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})(Z?)$/);
+  if (dtMatch) {
+    const [, y, m, d, hh, mm, ss, z] = dtMatch;
+    return `${y}-${m}-${d}T${hh}:${mm}:${ss}${z}`;
+  }
+
+  return cleaned;
+}
+
+export function parseCalendarObject(obj: DAVCalendarObject): CalendarEvent {
+  const vevent = extractVEvent(obj.data || '');
+  const title = parseICalValue(vevent, 'SUMMARY') || 'Untitled';
+  const description = parseICalValue(vevent, 'DESCRIPTION');
+  const rawStart = parseICalValue(vevent, 'DTSTART');
+  const rawEnd = parseICalValue(vevent, 'DTEND');
+  const location = parseICalValue(vevent, 'LOCATION');
+  const uid = parseICalValue(vevent, 'UID') || obj.url || '';
+
+  return {
+    id: uid,
+    url: obj.url || '',
+    title,
+    description: description?.replace(/\\n/g, '\n').replace(/\\,/g, ',') || undefined,
+    start: formatICalDate(rawStart),
+    end: formatICalDate(rawEnd),
+    location: location?.replace(/\\,/g, ',') || undefined,
+  };
+}
+
+export class CalDAVCalendarClient {
+  private config: CalDAVConfig;
+  private client: DAVClient | null = null;
+  private calendars: DAVCalendar[] | null = null;
+
+  constructor(config: CalDAVConfig) {
+    this.config = config;
+  }
+
+  private async getClient(): Promise<DAVClient> {
+    if (this.client) return this.client;
+
+    this.client = new DAVClient({
+      serverUrl: this.config.serverUrl || 'https://caldav.fastmail.com',
+      credentials: {
+        username: this.config.username,
+        password: this.config.password,
+      },
+      authMethod: 'Basic',
+      defaultAccountType: 'caldav',
+    });
+
+    await this.client.login();
+    return this.client;
+  }
+
+  async getCalendars(): Promise<CalendarInfo[]> {
+    const client = await this.getClient();
+    const calendars = await client.fetchCalendars();
+    this.calendars = calendars;
+
+    return calendars
+      .filter(c => c.displayName !== 'DEFAULT_TASK_CALENDAR_NAME')
+      .map(c => ({
+        id: c.url || '',
+        displayName: String(c.displayName || 'Unnamed'),
+        url: c.url || '',
+        description: c.description || undefined,
+        color: (c as any).calendarColor || undefined,
+      }));
+  }
+
+  async getCalendarEvents(calendarId?: string, limit: number = 50): Promise<CalendarEvent[]> {
+    const client = await this.getClient();
+
+    if (!this.calendars) {
+      this.calendars = await client.fetchCalendars();
+    }
+
+    let targetCalendars = this.calendars.filter(
+      c => c.displayName !== 'DEFAULT_TASK_CALENDAR_NAME'
+    );
+    if (calendarId) {
+      targetCalendars = targetCalendars.filter(
+        c => c.url === calendarId || c.displayName === calendarId
+      );
+    }
+
+    const allEvents: CalendarEvent[] = [];
+    for (const cal of targetCalendars) {
+      const objects = await client.fetchCalendarObjects({ calendar: cal });
+      for (const obj of objects) {
+        allEvents.push(parseCalendarObject(obj));
+      }
+      if (allEvents.length >= limit) break;
+    }
+
+    return allEvents.slice(0, limit);
+  }
+
+  async getCalendarEventById(eventId: string): Promise<CalendarEvent | null> {
+    const client = await this.getClient();
+
+    if (!this.calendars) {
+      this.calendars = await client.fetchCalendars();
+    }
+
+    for (const cal of this.calendars) {
+      const objects = await client.fetchCalendarObjects({ calendar: cal });
+      for (const obj of objects) {
+        const vevent = extractVEvent(obj.data || '');
+        const uid = parseICalValue(vevent, 'UID');
+        if (uid === eventId || obj.url === eventId) {
+          return parseCalendarObject(obj);
+        }
+      }
+    }
+
+    return null;
+  }
+
+  async createCalendarEvent(event: {
+    calendarId: string;
+    title: string;
+    description?: string;
+    start: string;
+    end: string;
+    location?: string;
+  }): Promise<string> {
+    const client = await this.getClient();
+
+    if (!this.calendars) {
+      this.calendars = await client.fetchCalendars();
+    }
+
+    const targetCal = this.calendars.find(
+      c => c.url === event.calendarId || c.displayName === event.calendarId
+    );
+    if (!targetCal) {
+      throw new Error(`Calendar not found: ${event.calendarId}`);
+    }
+
+    const uid = `${Date.now()}-${Math.random().toString(36).slice(2)}@fastmail-mcp`;
+    const now = new Date().toISOString().replace(/[-:]/g, '').replace(/\.\d{3}/, '');
+    const ical = [
+      'BEGIN:VCALENDAR',
+      'VERSION:2.0',
+      'PRODID:-//fastmail-mcp//CalDAV//EN',
+      'BEGIN:VEVENT',
+      `UID:${uid}`,
+      `DTSTAMP:${now}`,
+      `DTSTART:${event.start.replace(/[-:]/g, '')}`,
+      `DTEND:${event.end.replace(/[-:]/g, '')}`,
+      `SUMMARY:${event.title}`,
+      event.description ? `DESCRIPTION:${event.description}` : '',
+      event.location ? `LOCATION:${event.location}` : '',
+      'END:VEVENT',
+      'END:VCALENDAR',
+    ].filter(Boolean).join('\r\n');
+
+    await client.createCalendarObject({
+      calendar: targetCal,
+      filename: `${uid}.ics`,
+      iCalString: ical,
+    });
+
+    return uid;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
 import { FastmailAuth, FastmailConfig } from './auth.js';
 import { JmapClient } from './jmap-client.js';
 import { ContactsCalendarClient } from './contacts-calendar.js';
+import { CalDAVCalendarClient } from './caldav-client.js';
 
 const server = new Server(
   {
@@ -25,6 +26,7 @@ const server = new Server(
 
 let jmapClient: JmapClient | null = null;
 let contactsCalendarClient: ContactsCalendarClient | null = null;
+let caldavClient: CalDAVCalendarClient | null = null;
 
 function resolveEnvValue(...keys: string[]): string | undefined {
   const isPlaceholder = (val: string) => /\$\{[^}]+\}/.test(val.trim());
@@ -130,6 +132,24 @@ function initializeContactsCalendarClient(): ContactsCalendarClient {
   const auth = new FastmailAuth(config);
   contactsCalendarClient = new ContactsCalendarClient(auth);
   return contactsCalendarClient;
+}
+
+function initializeCalDAVClient(): CalDAVCalendarClient | null {
+  if (caldavClient) return caldavClient;
+
+  const username = findEnvValue([
+    'FASTMAIL_CALDAV_USERNAME',
+    'USER_CONFIG_FASTMAIL_CALDAV_USERNAME',
+  ]).value;
+  const password = findEnvValue([
+    'FASTMAIL_CALDAV_PASSWORD',
+    'USER_CONFIG_FASTMAIL_CALDAV_PASSWORD',
+  ]).value;
+
+  if (!username || !password) return null;
+
+  caldavClient = new CalDAVCalendarClient({ username, password });
+  return caldavClient;
 }
 
 server.setRequestHandler(ListToolsRequestSchema, async () => {
@@ -1151,30 +1171,35 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'list_calendars': {
-        const contactsClient = initializeContactsCalendarClient();
-        const calendars = await contactsClient.getCalendars();
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(calendars, null, 2),
-            },
-          ],
-        };
+        try {
+          const contactsClient = initializeContactsCalendarClient();
+          const calendars = await contactsClient.getCalendars();
+          return { content: [{ type: 'text', text: JSON.stringify(calendars, null, 2) }] };
+        } catch {
+          // JMAP calendars not available, try CalDAV
+          const davClient = initializeCalDAVClient();
+          if (!davClient) {
+            throw new McpError(ErrorCode.InvalidRequest, 'JMAP calendars not available and CalDAV not configured. Set FASTMAIL_CALDAV_USERNAME and FASTMAIL_CALDAV_PASSWORD to use CalDAV.');
+          }
+          const calendars = await davClient.getCalendars();
+          return { content: [{ type: 'text', text: JSON.stringify(calendars, null, 2) }] };
+        }
       }
 
       case 'list_calendar_events': {
         const { calendarId, limit = 50 } = args as any;
-        const contactsClient = initializeContactsCalendarClient();
-        const events = await contactsClient.getCalendarEvents(calendarId, limit);
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(events, null, 2),
-            },
-          ],
-        };
+        try {
+          const contactsClient = initializeContactsCalendarClient();
+          const events = await contactsClient.getCalendarEvents(calendarId, limit);
+          return { content: [{ type: 'text', text: JSON.stringify(events, null, 2) }] };
+        } catch {
+          const davClient = initializeCalDAVClient();
+          if (!davClient) {
+            throw new McpError(ErrorCode.InvalidRequest, 'JMAP calendars not available and CalDAV not configured. Set FASTMAIL_CALDAV_USERNAME and FASTMAIL_CALDAV_PASSWORD to use CalDAV.');
+          }
+          const events = await davClient.getCalendarEvents(calendarId, limit);
+          return { content: [{ type: 'text', text: JSON.stringify(events, null, 2) }] };
+        }
       }
 
       case 'get_calendar_event': {
@@ -1182,16 +1207,18 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         if (!eventId) {
           throw new McpError(ErrorCode.InvalidParams, 'eventId is required');
         }
-        const contactsClient = initializeContactsCalendarClient();
-        const event = await contactsClient.getCalendarEventById(eventId);
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(event, null, 2),
-            },
-          ],
-        };
+        try {
+          const contactsClient = initializeContactsCalendarClient();
+          const event = await contactsClient.getCalendarEventById(eventId);
+          return { content: [{ type: 'text', text: JSON.stringify(event, null, 2) }] };
+        } catch {
+          const davClient = initializeCalDAVClient();
+          if (!davClient) {
+            throw new McpError(ErrorCode.InvalidRequest, 'JMAP calendars not available and CalDAV not configured. Set FASTMAIL_CALDAV_USERNAME and FASTMAIL_CALDAV_PASSWORD to use CalDAV.');
+          }
+          const event = await davClient.getCalendarEventById(eventId);
+          return { content: [{ type: 'text', text: JSON.stringify(event, null, 2) }] };
+        }
       }
 
       case 'create_calendar_event': {
@@ -1199,24 +1226,22 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         if (!calendarId || !title || !start || !end) {
           throw new McpError(ErrorCode.InvalidParams, 'calendarId, title, start, and end are required');
         }
-        const contactsClient = initializeContactsCalendarClient();
-        const eventId = await contactsClient.createCalendarEvent({
-          calendarId,
-          title,
-          description,
-          start,
-          end,
-          location,
-          participants,
-        });
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Calendar event created successfully. Event ID: ${eventId}`,
-            },
-          ],
-        };
+        try {
+          const contactsClient = initializeContactsCalendarClient();
+          const eventId = await contactsClient.createCalendarEvent({
+            calendarId, title, description, start, end, location, participants,
+          });
+          return { content: [{ type: 'text', text: `Calendar event created successfully. Event ID: ${eventId}` }] };
+        } catch {
+          const davClient = initializeCalDAVClient();
+          if (!davClient) {
+            throw new McpError(ErrorCode.InvalidRequest, 'JMAP calendars not available and CalDAV not configured. Set FASTMAIL_CALDAV_USERNAME and FASTMAIL_CALDAV_PASSWORD to use CalDAV.');
+          }
+          const eventId = await davClient.createCalendarEvent({
+            calendarId, title, description, start, end, location,
+          });
+          return { content: [{ type: 'text', text: `Calendar event created via CalDAV. Event ID: ${eventId}` }] };
+        }
       }
 
       case 'list_identities': {


### PR DESCRIPTION
## Summary

Fastmail does not currently expose calendar access via JMAP API tokens — the `urn:ietf:params:jmap:calendars` scope is not available because the JMAP Calendars specification is still an IETF Internet-Draft ([draft-ietf-jmap-calendars-26](https://datatracker.ietf.org/doc/draft-ietf-jmap-calendars/)). Fastmail has stated they will add JMAP calendar support once the spec is finalized as an RFC, but there is no public timeline.

However, Fastmail fully supports **CalDAV** for calendar access via `caldav.fastmail.com`, using Basic auth with an app-specific password.

This PR makes the existing calendar tools (`list_calendars`, `list_calendar_events`, `get_calendar_event`, `create_calendar_event`) actually work by adding a **CalDAV fallback**: when JMAP calendar access is unavailable, the server automatically falls back to CalDAV if the `FASTMAIL_CALDAV_USERNAME` and `FASTMAIL_CALDAV_PASSWORD` environment variables are configured.

## Changes

- **New file: `src/caldav-client.ts`** — CalDAV client using `tsdav` library with proper iCal parsing (handles VTIMEZONE blocks, parameterized dates, all-day events, line folding)
- **Modified: `src/index.ts`** — Calendar tool handlers now try JMAP first, then automatically fall back to CalDAV
- **New dependency: `tsdav`** — Lightweight TypeScript CalDAV library
- **New file: `src/caldav-client.test.ts`** — Unit tests for iCal parsing
- **Updated: `README.md`** — CalDAV setup instructions

## Configuration

Two new optional environment variables:
- `FASTMAIL_CALDAV_USERNAME` — Your Fastmail email address
- `FASTMAIL_CALDAV_PASSWORD` — An app-specific password (Settings → Privacy & Security → Manage app passwords)

When these are not set, the server behaves exactly as before (JMAP only).

## Test plan

- [ ] `list_calendars` returns calendars via CalDAV when JMAP calendars unavailable
- [ ] `list_calendar_events` returns events with correct ISO 8601 dates
- [ ] Date parsing handles VTIMEZONE blocks (doesn't pick up timezone DTSTART)
- [ ] Date parsing handles all formats: datetime with TZID, UTC, all-day
- [ ] `create_calendar_event` creates events readable by Fastmail web UI
- [ ] Existing tests still pass
- [ ] Build succeeds with no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)