### PR TITLE
Add support for pinned (flagged) email.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -564,6 +564,25 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         },
       },
       {
+        name: 'pin_email',
+        description: 'Pin or unpin an email',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            emailId: {
+              type: 'string',
+              description: 'ID of the email to pin/unpin',
+            },
+            pinned: {
+              type: 'boolean',
+              description: 'true to pin, false to unpin',
+              default: true,
+            },
+          },
+          required: ['emailId'],
+        },
+      },
+      {
         name: 'delete_email',
         description: 'Delete an email (move to trash)',
         inputSchema: {
@@ -699,6 +718,10 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               type: 'boolean',
               description: 'Filter unread emails',
             },
+            isPinned: {
+              type: 'boolean',
+              description: 'Filter pinned emails',
+            },
             mailboxId: {
               type: 'string',
               description: 'Search within specific mailbox',
@@ -768,6 +791,26 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             read: {
               type: 'boolean',
               description: 'true to mark as read, false as unread',
+              default: true,
+            },
+          },
+          required: ['emailIds'],
+        },
+      },
+      {
+        name: 'bulk_pin',
+        description: 'Pin or unpin multiple emails',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            emailIds: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Array of email IDs to pin/unpin',
+            },
+            pinned: {
+              type: 'boolean',
+              description: 'true to pin, false to unpin',
               default: true,
             },
           },
@@ -1264,6 +1307,23 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
       }
 
+      case 'pin_email': {
+        const { emailId, pinned = true } = args as any;
+        if (!emailId) {
+          throw new McpError(ErrorCode.InvalidParams, 'emailId is required');
+        }
+        const client = initializeClient();
+        await client.pinEmail(emailId, pinned);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Email ${pinned ? 'pinned' : 'unpinned'} successfully`,
+            },
+          ],
+        };
+      }
+
       case 'delete_email': {
         const { emailId } = args as any;
         if (!emailId) {
@@ -1393,10 +1453,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'advanced_search': {
-        const { query, from, to, subject, hasAttachment, isUnread, mailboxId, after, before, limit } = args as any;
+        const { query, from, to, subject, hasAttachment, isUnread, isPinned, mailboxId, after, before, limit } = args as any;
         const client = initializeClient();
         const emails = await client.advancedSearch({
-          query, from, to, subject, hasAttachment, isUnread, mailboxId, after, before, limit
+          query, from, to, subject, hasAttachment, isUnread, isPinned, mailboxId, after, before, limit
         });
         return {
           content: [
@@ -1469,6 +1529,23 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             {
               type: 'text',
               text: `${emailIds.length} emails ${read ? 'marked as read' : 'marked as unread'} successfully`,
+            },
+          ],
+        };
+      }
+
+      case 'bulk_pin': {
+        const { emailIds, pinned = true } = args as any;
+        if (!emailIds || !Array.isArray(emailIds) || emailIds.length === 0) {
+          throw new McpError(ErrorCode.InvalidParams, 'emailIds array is required and must not be empty');
+        }
+        const client = initializeClient();
+        await client.bulkPinEmails(emailIds, pinned);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `${emailIds.length} emails ${pinned ? 'pinned' : 'unpinned'} successfully`,
             },
           ],
         };
@@ -1560,9 +1637,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             available: true,
             functions: [
               'list_mailboxes', 'list_emails', 'get_email', 'send_email', 'create_draft', 'search_emails',
-              'get_recent_emails', 'mark_email_read', 'delete_email', 'move_email',
+              'get_recent_emails', 'mark_email_read', 'pin_email', 'delete_email', 'move_email',
               'get_email_attachments', 'download_attachment', 'advanced_search', 'get_thread',
-              'get_mailbox_stats', 'get_account_summary', 'bulk_mark_read', 'bulk_move', 'bulk_delete',
+              'get_mailbox_stats', 'get_account_summary', 'bulk_mark_read', 'bulk_pin', 'bulk_move', 'bulk_delete',
               'add_labels', 'remove_labels', 'bulk_add_labels', 'bulk_remove_labels'
             ]
           },

--- a/src/jmap-client.ts
+++ b/src/jmap-client.ts
@@ -605,6 +605,32 @@ export class JmapClient {
     }
   }
 
+  async pinEmail(emailId: string, pinned: boolean = true): Promise<void> {
+    const session = await this.getSession();
+
+    const update: Record<string, any> = {};
+    update[emailId] = pinned
+      ? { 'keywords/$flagged': true }
+      : { 'keywords/$flagged': null };
+
+    const request: JmapRequest = {
+      using: ['urn:ietf:params:jmap:core', 'urn:ietf:params:jmap:mail'],
+      methodCalls: [
+        ['Email/set', {
+          accountId: session.accountId,
+          update
+        }, 'pinEmail']
+      ]
+    };
+
+    const response = await this.makeRequest(request);
+    const result = this.getMethodResult(response, 0);
+
+    if (result.notUpdated && result.notUpdated[emailId]) {
+      throw new Error(`Failed to ${pinned ? 'pin' : 'unpin'} email.`);
+    }
+  }
+
   async deleteEmail(emailId: string): Promise<void> {
     const session = await this.getSession();
     
@@ -908,6 +934,7 @@ export class JmapClient {
     subject?: string;
     hasAttachment?: boolean;
     isUnread?: boolean;
+    isPinned?: boolean;
     mailboxId?: string;
     after?: string;
     before?: string;
@@ -923,15 +950,24 @@ export class JmapClient {
     if (filters.to) filter.to = filters.to;
     if (filters.subject) filter.subject = filters.subject;
     if (filters.hasAttachment !== undefined) filter.hasAttachment = filters.hasAttachment;
-    if (filters.isUnread !== undefined) filter.hasKeyword = filters.isUnread ? undefined : '$seen';
+    if (filters.isUnread === true) filter.notKeyword = '$seen';
+    else if (filters.isUnread === false) filter.hasKeyword = '$seen';
+    if (filters.isPinned === true) filter.hasKeyword = '$flagged';
+    if (filters.isPinned === false) filter.notKeyword = '$flagged';
     if (filters.mailboxId) filter.inMailbox = filters.mailboxId;
     if (filters.after) filter.after = filters.after;
     if (filters.before) filter.before = filters.before;
 
-    // If unread filter is specifically true, we need to check for absence of $seen
-    if (filters.isUnread === true) {
-      filter.notKeyword = '$seen';
+    // When both isUnread and isPinned are set, hasKeyword/notKeyword may conflict.
+    // JMAP FilterCondition only supports one hasKeyword, so wrap in an AND operator.
+    let finalFilter: any = filter;
+    if (filters.isUnread !== undefined && filters.isPinned !== undefined) {
       delete filter.hasKeyword;
+      delete filter.notKeyword;
+      const conditions: any[] = [filter];
+      conditions.push(filters.isUnread ? { notKeyword: '$seen' } : { hasKeyword: '$seen' });
+      conditions.push(filters.isPinned ? { hasKeyword: '$flagged' } : { notKeyword: '$flagged' });
+      finalFilter = { operator: 'AND', conditions };
     }
 
     const request: JmapRequest = {
@@ -939,7 +975,7 @@ export class JmapClient {
       methodCalls: [
         ['Email/query', {
           accountId: session.accountId,
-          filter,
+          filter: finalFilter,
           sort: [{ property: 'receivedAt', isAscending: false }],
           limit: Math.min(filters.limit || 50, 100)
         }, 'query'],
@@ -1121,6 +1157,34 @@ export class JmapClient {
     
     if (result.notUpdated && Object.keys(result.notUpdated).length > 0) {
       throw new Error('Failed to update some emails.');
+    }
+  }
+
+  async bulkPinEmails(emailIds: string[], pinned: boolean = true): Promise<void> {
+    const session = await this.getSession();
+
+    const updates: Record<string, any> = {};
+    emailIds.forEach(id => {
+      updates[id] = pinned
+        ? { 'keywords/$flagged': true }
+        : { 'keywords/$flagged': null };
+    });
+
+    const request: JmapRequest = {
+      using: ['urn:ietf:params:jmap:core', 'urn:ietf:params:jmap:mail'],
+      methodCalls: [
+        ['Email/set', {
+          accountId: session.accountId,
+          update: updates
+        }, 'bulkFlag']
+      ]
+    };
+
+    const response = await this.makeRequest(request);
+    const result = this.getMethodResult(response, 0);
+
+    if (result.notUpdated && Object.keys(result.notUpdated).length > 0) {
+      throw new Error('Failed to pin/unpin some emails.');
     }
   }
 


### PR DESCRIPTION
- Adds `pin_email` and `bulk_pin` tools to pin/unpin emails using the JMAP `$flagged` keyword
- Adds `isPinned` filter to `advanced_search` with compound filter handling when combined with `isUnread` (JMAP seems to expose only a single hasKeyword / notKeyword so when we're looking for, say, both unread and not-pinned, we can't have two notKeywords.

Tested on my own fastmail account.