### PR TITLE
feat: add startDate/endDate filtering to list_calendar_events (CalDAV)

### DIFF
--- a/src/caldav-client.test.ts
+++ b/src/caldav-client.test.ts
@@ -1,10 +1,11 @@
-import { describe, it } from 'node:test';
+import { describe, it, mock } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   extractVEvent,
   parseICalValue,
   formatICalDate,
   parseCalendarObject,
+  CalDAVCalendarClient,
 } from './caldav-client.js';
 
 describe('extractVEvent', () => {
@@ -221,5 +222,73 @@ describe('parseCalendarObject', () => {
     assert.equal(event.description, undefined);
     assert.equal(event.location, undefined);
     assert.equal(event.end, undefined);
+  });
+});
+
+describe('CalDAVCalendarClient.getCalendarEvents', () => {
+  function makeIcal(uid: string, summary: string, dtstart: string): string {
+    return [
+      'BEGIN:VCALENDAR',
+      'BEGIN:VEVENT',
+      `UID:${uid}`,
+      `DTSTART:${dtstart}`,
+      `SUMMARY:${summary}`,
+      'END:VEVENT',
+      'END:VCALENDAR',
+    ].join('\r\n');
+  }
+
+  function createMockedClient(calendarObjects: Array<{ data: string; url: string }>) {
+    const client = new CalDAVCalendarClient({ username: 'test', password: 'test' });
+    // Override the private getClient method to return a mock DAVClient
+    const mockDAVClient = {
+      login: mock.fn(async () => {}),
+      fetchCalendars: mock.fn(async () => [
+        { displayName: 'Personal', url: '/cal/personal/' },
+      ]),
+      fetchCalendarObjects: mock.fn(async () => calendarObjects),
+    };
+    (client as any).client = mockDAVClient;
+    return { client, mockDAVClient };
+  }
+
+  it('sorts events by start date ascending', async () => {
+    const objects = [
+      { data: makeIcal('c@fm', 'Evening', '20260325T200000Z'), url: '/c.ics' },
+      { data: makeIcal('a@fm', 'Morning', '20260325T080000Z'), url: '/a.ics' },
+      { data: makeIcal('b@fm', 'Afternoon', '20260325T140000Z'), url: '/b.ics' },
+    ];
+    const { client } = createMockedClient(objects);
+    const events = await client.getCalendarEvents(undefined, 50);
+
+    assert.equal(events.length, 3);
+    assert.equal(events[0].title, 'Morning');
+    assert.equal(events[1].title, 'Afternoon');
+    assert.equal(events[2].title, 'Evening');
+  });
+
+  it('passes timeRange to fetchCalendarObjects when startDate/endDate provided', async () => {
+    const objects = [
+      { data: makeIcal('a@fm', 'Event', '20260325T100000Z'), url: '/a.ics' },
+    ];
+    const { client, mockDAVClient } = createMockedClient(objects);
+    await client.getCalendarEvents(undefined, 50, '2026-03-25T00:00:00Z', '2026-03-26T00:00:00Z');
+
+    const callArgs = mockDAVClient.fetchCalendarObjects.mock.calls[0].arguments[0];
+    assert.deepEqual(callArgs.timeRange, {
+      start: '2026-03-25T00:00:00Z',
+      end: '2026-03-26T00:00:00Z',
+    });
+  });
+
+  it('does not pass timeRange when no dates provided', async () => {
+    const objects = [
+      { data: makeIcal('a@fm', 'Event', '20260325T100000Z'), url: '/a.ics' },
+    ];
+    const { client, mockDAVClient } = createMockedClient(objects);
+    await client.getCalendarEvents(undefined, 50);
+
+    const callArgs = mockDAVClient.fetchCalendarObjects.mock.calls[0].arguments[0];
+    assert.equal(callArgs.timeRange, undefined);
   });
 });

--- a/src/caldav-client.ts
+++ b/src/caldav-client.ts
@@ -154,7 +154,7 @@ export class CalDAVCalendarClient {
       }));
   }
 
-  async getCalendarEvents(calendarId?: string, limit: number = 50): Promise<CalendarEvent[]> {
+  async getCalendarEvents(calendarId?: string, limit: number = 50, startDate?: string, endDate?: string): Promise<CalendarEvent[]> {
     const client = await this.getClient();
 
     if (!this.calendars) {
@@ -170,14 +170,25 @@ export class CalDAVCalendarClient {
       );
     }
 
+    const fetchOptions: any = {};
+    if (startDate || endDate) {
+      fetchOptions.timeRange = {
+        start: startDate || '1970-01-01T00:00:00Z',
+        end: endDate || '2099-12-31T23:59:59Z',
+      };
+    }
+
     const allEvents: CalendarEvent[] = [];
     for (const cal of targetCalendars) {
-      const objects = await client.fetchCalendarObjects({ calendar: cal });
+      const objects = await client.fetchCalendarObjects({ calendar: cal, ...fetchOptions });
       for (const obj of objects) {
         allEvents.push(parseCalendarObject(obj));
       }
       if (allEvents.length >= limit) break;
     }
+
+    // Sort by start date ascending
+    allEvents.sort((a, b) => (a.start || '').localeCompare(b.start || ''));
 
     return allEvents.slice(0, limit);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -450,6 +450,14 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               type: 'string',
               description: 'ID of the calendar (optional, defaults to all calendars)',
             },
+            startDate: {
+              type: 'string',
+              description: 'Filter events starting from this date (ISO 8601, e.g. 2026-03-23T00:00:00Z)',
+            },
+            endDate: {
+              type: 'string',
+              description: 'Filter events ending before this date (ISO 8601, e.g. 2026-03-30T00:00:00Z)',
+            },
             limit: {
               type: 'number',
               description: 'Maximum number of events to return (default: 50)',
@@ -1244,7 +1252,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'list_calendar_events': {
-        const { calendarId, limit = 50 } = args as any;
+        const { calendarId, limit = 50, startDate, endDate } = args as any;
         try {
           const contactsClient = initializeContactsCalendarClient();
           const events = await contactsClient.getCalendarEvents(calendarId, limit);
@@ -1254,7 +1262,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           if (!davClient) {
             throw new McpError(ErrorCode.InvalidRequest, 'JMAP calendars not available and CalDAV not configured. Set FASTMAIL_CALDAV_USERNAME and FASTMAIL_CALDAV_PASSWORD to use CalDAV.');
           }
-          const events = await davClient.getCalendarEvents(calendarId, limit);
+          const events = await davClient.getCalendarEvents(calendarId, limit, startDate, endDate);
           return { content: [{ type: 'text', text: JSON.stringify(events, null, 2) }] };
         }
       }


### PR DESCRIPTION
## Summary

- Adds `startDate` and `endDate` optional parameters to the `list_calendar_events` CalDAV tool for time-range filtering
- Without filtering, the tool returns **all** events from the calendar history, which can be hundreds/thousands of events — impractical for daily use (e.g. "show me today's events")
- Uses tsdav's native `timeRange` option in `fetchCalendarObjects` for efficient server-side filtering
- Results are now sorted by start date ascending

## Changes

- **`src/caldav-client.ts`** — Added `startDate`/`endDate` params to `getCalendarEvents()`, builds a `timeRange` object passed to tsdav's `fetchCalendarObjects`, and sorts results by start date
- **`src/index.ts`** — Added `startDate`/`endDate` to the tool schema (ISO 8601 format) and wired them through the handler to the CalDAV client

## Test plan

- [x] Tested locally against Fastmail CalDAV with various date ranges
- [x] Verify events outside the date range are excluded
- [x] Verify omitting both params returns all events (backward compatible)
- [x] Verify providing only `startDate` or only `endDate` works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)