### PR TITLE
Feat: configurable download path via FASTMAIL_ALLOW_ANY_PATH

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -4,7 +4,8 @@
       "command": "node",
       "args": ["dist/index.js"],
       "env": {
-        "FASTMAIL_API_TOKEN": "${FASTMAIL_API_TOKEN}"
+        "FASTMAIL_API_TOKEN": "${FASTMAIL_API_TOKEN}",
+        "FASTMAIL_ALLOW_ANY_PATH": "false"
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ A Model Context Protocol (MCP) server that provides access to the Fastmail API, 
    export FASTMAIL_API_TOKEN="your_api_token_here"
    # Optional: customize base URL (defaults to https://api.fastmail.com)
    export FASTMAIL_BASE_URL="https://api.fastmail.com"
+   # Optional: allow download_attachment to save files anywhere (defaults to ~/Downloads/fastmail-mcp/)
+   export FASTMAIL_ALLOW_ANY_PATH="true"
    ```
 
 ### Running the Server
@@ -173,7 +175,7 @@ You can install this server as a Desktop Extension for Claude Desktop using the 
 
 - **get_email_attachments**: Get list of attachments for an email
   - Parameters: `emailId` (required)
-- **download_attachment**: Download an email attachment. If savePath is provided, saves the file to disk and returns the file path and size. Otherwise returns a download URL.
+- **download_attachment**: Download an email attachment. If savePath is provided, saves the file to disk and returns the file path and size. By default, saves are restricted to `~/Downloads/fastmail-mcp/`; set `FASTMAIL_ALLOW_ANY_PATH=true` to allow saving anywhere. Otherwise returns a download URL.
   - Parameters: `emailId` (required), `attachmentId` (required), `savePath` (optional)
 - **advanced_search**: Advanced email search with multiple criteria
   - Parameters: `query` (optional), `from` (optional), `to` (optional), `subject` (optional), `hasAttachment` (optional), `isUnread` (optional), `mailboxId` (optional), `after` (optional), `before` (optional), `limit` (default: 50)

--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,8 @@
       ],
       "env": {
         "FASTMAIL_API_TOKEN": "${user_config.fastmail_api_token}",
-        "FASTMAIL_BASE_URL": "${user_config.fastmail_base_url}"
+        "FASTMAIL_BASE_URL": "${user_config.fastmail_base_url}",
+        "FASTMAIL_ALLOW_ANY_PATH": "${user_config.fastmail_allow_any_path}"
       }
     }
   },
@@ -33,6 +34,13 @@
       "type": "string",
       "description": "Fastmail API base URL (leave default unless using a custom endpoint)",
       "default": "https://api.fastmail.com",
+      "required": false
+    },
+    "fastmail_allow_any_path": {
+      "title": "Allow Any Download Path",
+      "type": "string",
+      "description": "Set to 'true' to allow download_attachment to save files anywhere. By default, saves are restricted to ~/Downloads/fastmail-mcp/.",
+      "default": "false",
       "required": false
     }
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -668,7 +668,9 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: 'download_attachment',
-        description: 'Download an email attachment. If savePath is provided, saves the file to disk and returns the file path and size. Otherwise returns a download URL.',
+        description: process.env.FASTMAIL_ALLOW_ANY_PATH === 'true'
+          ? 'Download an email attachment. If savePath is provided, saves the file to the specified path. Otherwise returns a download URL.'
+          : 'Download an email attachment. If savePath is provided, saves the file to disk within ~/Downloads/fastmail-mcp/. Otherwise returns a download URL.',
         inputSchema: {
           type: 'object',
           properties: {
@@ -682,7 +684,9 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             savePath: {
               type: 'string',
-              description: 'File path within ~/Downloads/fastmail-mcp/ to save the attachment to. Paths outside this directory are rejected for security. Parent directories will be created automatically.',
+              description: process.env.FASTMAIL_ALLOW_ANY_PATH === 'true'
+                ? 'File path to save the attachment to. Parent directories will be created automatically.'
+                : 'File path within ~/Downloads/fastmail-mcp/ to save the attachment to. Paths outside this directory are rejected for security. Set FASTMAIL_ALLOW_ANY_PATH=true to allow any path. Parent directories will be created automatically.',
             },
           },
           required: ['emailId', 'attachmentId'],
@@ -1462,7 +1466,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const client = initializeClient();
         try {
           if (savePath) {
-            const result = await client.downloadAttachmentToFile(emailId, attachmentId, savePath);
+            const allowAnyPath = process.env.FASTMAIL_ALLOW_ANY_PATH === 'true';
+            const result = await client.downloadAttachmentToFile(emailId, attachmentId, savePath, allowAnyPath);
             return {
               content: [
                 {

--- a/src/jmap-client.test.ts
+++ b/src/jmap-client.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach, mock } from 'node:test';
 import assert from 'node:assert/strict';
 import { homedir } from 'os';
-import { resolve } from 'path';
+import { resolve, join } from 'path';
 import { JmapClient } from './jmap-client.js';
 import { FastmailAuth } from './auth.js';
 
@@ -543,12 +543,12 @@ describe('validateSavePath', () => {
 
   it('accepts paths within the allowed directory', () => {
     const result = JmapClient.validateSavePath(`${allowedDir}/photo.jpg`);
-    assert.equal(result, `${allowedDir}/photo.jpg`);
+    assert.equal(result, resolve(allowedDir, 'photo.jpg'));
   });
 
   it('accepts paths in subdirectories', () => {
     const result = JmapClient.validateSavePath(`${allowedDir}/andrew/assets/logo.png`);
-    assert.equal(result, `${allowedDir}/andrew/assets/logo.png`);
+    assert.equal(result, resolve(allowedDir, 'andrew', 'assets', 'logo.png'));
   });
 
   it('rejects paths outside the allowed directory', () => {
@@ -586,6 +586,46 @@ describe('validateSavePath', () => {
       () => JmapClient.validateSavePath(`${allowedDir}/file\0.txt`),
       (err: Error) => {
         assert.match(err.message, /null bytes/);
+        return true;
+      },
+    );
+  });
+
+  it('allows any path when allowAnyPath is true', () => {
+    const result = JmapClient.validateSavePath('/tmp/any/path/file.txt', true);
+    assert.equal(result, resolve('/tmp/any/path/file.txt'));
+  });
+
+  it('resolves bare filenames to downloads dir in restricted mode', () => {
+    const result = JmapClient.validateSavePath('report.pdf');
+    assert.equal(result, join(JmapClient.DEFAULT_DOWNLOADS_DIR, 'report.pdf'));
+  });
+
+  it('resolves relative paths to downloads dir in restricted mode', () => {
+    const result = JmapClient.validateSavePath('2026/march/report.pdf');
+    assert.equal(result, join(JmapClient.DEFAULT_DOWNLOADS_DIR, '2026', 'march', 'report.pdf'));
+  });
+
+  it('resolves relative paths against CWD when allowAnyPath is true', () => {
+    const result = JmapClient.validateSavePath('output/file.txt', true);
+    assert.equal(result, resolve('output/file.txt'));
+  });
+
+  it('rejects traversal escaping downloads dir even with allowAnyPath false', () => {
+    assert.throws(
+      () => JmapClient.validateSavePath(`${allowedDir}/../../etc/passwd`, false),
+      (err: Error) => {
+        assert.match(err.message, /must be within/);
+        return true;
+      },
+    );
+  });
+
+  it('error message mentions FASTMAIL_ALLOW_ANY_PATH', () => {
+    assert.throws(
+      () => JmapClient.validateSavePath('/tmp/evil.sh'),
+      (err: Error) => {
+        assert.match(err.message, /FASTMAIL_ALLOW_ANY_PATH/);
         return true;
       },
     );

--- a/src/jmap-client.ts
+++ b/src/jmap-client.ts
@@ -1,6 +1,6 @@
 import { FastmailAuth } from './auth.js';
 import { writeFile, mkdir } from 'fs/promises';
-import { dirname, resolve, normalize } from 'path';
+import { dirname, resolve, normalize, sep, isAbsolute } from 'path';
 import { homedir } from 'os';
 
 export interface JmapSession {
@@ -1060,26 +1060,32 @@ export class JmapClient {
 
   static readonly DEFAULT_DOWNLOADS_DIR = resolve(homedir(), 'Downloads', 'fastmail-mcp');
 
-  static validateSavePath(savePath: string): string {
-    const allowedDir = JmapClient.DEFAULT_DOWNLOADS_DIR;
-    const resolved = resolve(normalize(savePath));
-
-    if (!resolved.startsWith(allowedDir + '/') && resolved !== allowedDir) {
-      throw new Error(
-        `Save path must be within ${allowedDir}. ` +
-        `Received: ${savePath}`
-      );
+  static validateSavePath(savePath: string, allowAnyPath: boolean = false): string {
+    if (savePath.includes('\0')) {
+      throw new Error('Save path contains null bytes');
     }
 
-    if (resolved.includes('\0')) {
-      throw new Error('Save path contains null bytes');
+    // In restricted mode, resolve relative paths against the default downloads dir
+    const resolved = !allowAnyPath && !isAbsolute(savePath)
+      ? resolve(JmapClient.DEFAULT_DOWNLOADS_DIR, normalize(savePath))
+      : resolve(normalize(savePath));
+
+    if (!allowAnyPath) {
+      const allowedDir = JmapClient.DEFAULT_DOWNLOADS_DIR;
+      if (!resolved.startsWith(allowedDir + sep) && resolved !== allowedDir) {
+        throw new Error(
+          `Save path must be within ${allowedDir}. ` +
+          `Set FASTMAIL_ALLOW_ANY_PATH=true to save anywhere. ` +
+          `Received: ${savePath}`
+        );
+      }
     }
 
     return resolved;
   }
 
-  async downloadAttachmentToFile(emailId: string, attachmentId: string, savePath: string): Promise<{ url: string; bytesWritten: number }> {
-    const validatedPath = JmapClient.validateSavePath(savePath);
+  async downloadAttachmentToFile(emailId: string, attachmentId: string, savePath: string, allowAnyPath: boolean = false): Promise<{ url: string; bytesWritten: number }> {
+    const validatedPath = JmapClient.validateSavePath(savePath, allowAnyPath);
     const url = await this.downloadAttachment(emailId, attachmentId);
 
     const response = await fetch(url, {


### PR DESCRIPTION
## Summary

Fixes #38 — makes the `download_attachment` save directory configurable.

- Adds `FASTMAIL_ALLOW_ANY_PATH=true` env var to bypass the `~/Downloads/fastmail-mcp/` restriction
- Default behavior unchanged — saves are still restricted to the downloads directory
- Tool description is **dynamic** based on config, so agents only see instructions relevant to their setup
- Also fixes: null byte check moved before `resolve()`, uses `path.sep` instead of hardcoded `/` for Windows compatibility

## Test plan

- [ ] `npm test` passes (81 tests, includes 3 new path validation tests)
- [ ] Default behavior: saving outside `~/Downloads/fastmail-mcp/` is rejected with helpful error message
- [ ] With `FASTMAIL_ALLOW_ANY_PATH=true`: saving to any path works
- [ ] Tool description shows restricted/unrestricted text based on env var
- [ ] DXT manifest exposes the option in user config