### PR TITLE
Fix: markEmailRead/bulkMarkRead silently clobbers other keywords

### DIFF
--- a/src/jmap-client-extra.test.ts
+++ b/src/jmap-client-extra.test.ts
@@ -326,7 +326,7 @@ describe('markEmailRead', () => {
     await client.markEmailRead('e1', true);
 
     const update = makeReq.mock.calls[0].arguments[0].methodCalls[0][1].update;
-    assert.deepEqual(update['e1'].keywords, { $seen: true });
+    assert.deepEqual(update['e1'], { 'keywords/$seen': true });
   });
 
   it('marks email as unread', async () => {
@@ -339,7 +339,7 @@ describe('markEmailRead', () => {
     await client.markEmailRead('e1', false);
 
     const update = makeReq.mock.calls[0].arguments[0].methodCalls[0][1].update;
-    assert.deepEqual(update['e1'].keywords, {});
+    assert.deepEqual(update['e1'], { 'keywords/$seen': null });
   });
 
   it('throws when update fails', async () => {
@@ -378,9 +378,9 @@ describe('bulkMarkRead', () => {
     await client.bulkMarkRead(['e1', 'e2', 'e3'], true);
 
     const update = makeReq.mock.calls[0].arguments[0].methodCalls[0][1].update;
-    assert.deepEqual(update['e1'].keywords, { $seen: true });
-    assert.deepEqual(update['e2'].keywords, { $seen: true });
-    assert.deepEqual(update['e3'].keywords, { $seen: true });
+    assert.deepEqual(update['e1'], { 'keywords/$seen': true });
+    assert.deepEqual(update['e2'], { 'keywords/$seen': true });
+    assert.deepEqual(update['e3'], { 'keywords/$seen': true });
   });
 
   it('marks multiple emails as unread', async () => {
@@ -393,8 +393,8 @@ describe('bulkMarkRead', () => {
     await client.bulkMarkRead(['e1', 'e2'], false);
 
     const update = makeReq.mock.calls[0].arguments[0].methodCalls[0][1].update;
-    assert.deepEqual(update['e1'].keywords, {});
-    assert.deepEqual(update['e2'].keywords, {});
+    assert.deepEqual(update['e1'], { 'keywords/$seen': null });
+    assert.deepEqual(update['e2'], { 'keywords/$seen': null });
   });
 
   it('throws when some emails fail to update', async () => {

--- a/src/jmap-client.ts
+++ b/src/jmap-client.ts
@@ -728,19 +728,18 @@ export class JmapClient {
 
   async markEmailRead(emailId: string, read: boolean = true): Promise<void> {
     const session = await this.getSession();
-    
-    const keywords = read ? { $seen: true } : {};
-    
+
+    const update: Record<string, any> = {};
+    update[emailId] = read
+      ? { 'keywords/$seen': true }
+      : { 'keywords/$seen': null };
+
     const request: JmapRequest = {
       using: ['urn:ietf:params:jmap:core', 'urn:ietf:params:jmap:mail'],
       methodCalls: [
         ['Email/set', {
           accountId: session.accountId,
-          update: {
-            [emailId]: {
-              keywords
-            }
-          }
+          update
         }, 'updateEmail']
       ]
     };
@@ -1305,12 +1304,12 @@ export class JmapClient {
 
   async bulkMarkRead(emailIds: string[], read: boolean = true): Promise<void> {
     const session = await this.getSession();
-    
-    const keywords = read ? { $seen: true } : {};
+
     const updates: Record<string, any> = {};
-    
     emailIds.forEach(id => {
-      updates[id] = { keywords };
+      updates[id] = read
+        ? { 'keywords/$seen': true }
+        : { 'keywords/$seen': null };
     });
 
     const request: JmapRequest = {


### PR DESCRIPTION
## Summary

`markEmailRead` sets `keywords: { $seen: true }` which replaces the entire keywords object, silently wiping `$flagged`, `$draft`, and any other keywords. `bulkMarkRead` has the same bug.

Fixed to use JMAP patch syntax (`keywords/$seen`), matching how `pinEmail` and `bulkPinEmails` already work in the same file.

## Test plan

- [ ] `npm test` passes
- [ ] Mark a flagged email as read — `$flagged` keyword is preserved
- [ ] Mark a read email as unread — other keywords are preserved
- [ ] Bulk mark read preserves existing keywords