### PR TITLE
Feat: add ascending sort option to email list/search tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ You can install this server as a Desktop Extension for Claude Desktop using the 
 
 - **list_mailboxes**: Get all mailboxes in your account
 - **list_emails**: List emails from a specific mailbox or all mailboxes
-  - Parameters: `mailboxId` (optional), `limit` (default: 20)
+  - Parameters: `mailboxId` (optional), `limit` (default: 20), `ascending` (optional, oldest first)
 - **get_email**: Get a specific email by ID
   - Parameters: `emailId` (required)
 - **send_email**: Send an email (supports threading via optional `inReplyTo` and `references` headers)
@@ -155,9 +155,9 @@ You can install this server as a Desktop Extension for Claude Desktop using the 
 - **create_draft**: Create a minimal email draft (at least one of to/subject/body required)
   - Parameters: `to` (optional array), `cc` (optional array), `bcc` (optional array), `from` (optional), `mailboxId` (optional), `subject` (optional), `textBody` (optional), `htmlBody` (optional)
 - **search_emails**: Search emails by content
-  - Parameters: `query` (required), `limit` (default: 20)
+  - Parameters: `query` (required), `limit` (default: 20), `ascending` (optional, oldest first)
 - **get_recent_emails**: Get the most recent emails from a mailbox (inspired by JMAP-Samples top-ten)
-  - Parameters: `limit` (default: 10, max: 50), `mailboxName` (default: 'inbox')
+  - Parameters: `limit` (default: 10, max: 50), `mailboxName` (default: 'inbox'), `ascending` (optional, oldest first)
 - **mark_email_read**: Mark an email as read or unread
   - Parameters: `emailId` (required), `read` (default: true)
 - **delete_email**: Delete an email (move to trash)
@@ -176,7 +176,7 @@ You can install this server as a Desktop Extension for Claude Desktop using the 
 - **download_attachment**: Download an email attachment. If savePath is provided, saves the file to disk and returns the file path and size. Otherwise returns a download URL.
   - Parameters: `emailId` (required), `attachmentId` (required), `savePath` (optional)
 - **advanced_search**: Advanced email search with multiple criteria
-  - Parameters: `query` (optional), `from` (optional), `to` (optional), `subject` (optional), `hasAttachment` (optional), `isUnread` (optional), `mailboxId` (optional), `after` (optional), `before` (optional), `limit` (default: 50)
+  - Parameters: `query` (optional), `from` (optional), `to` (optional), `subject` (optional), `hasAttachment` (optional), `isUnread` (optional), `mailboxId` (optional), `after` (optional), `before` (optional), `limit` (default: 50), `ascending` (optional, oldest first)
 - **get_thread**: Get all emails in a conversation thread
   - Parameters: `threadId` (required)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,6 +136,10 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               description: 'Maximum number of emails to return (default: 20)',
               default: 20,
             },
+            ascending: {
+              type: 'boolean',
+              description: 'Sort oldest first instead of newest first (default: false)',
+            },
           },
         },
       },
@@ -381,6 +385,10 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               description: 'Maximum number of results (default: 20)',
               default: 20,
             },
+            ascending: {
+              type: 'boolean',
+              description: 'Sort oldest first instead of newest first (default: false)',
+            },
           },
           required: ['query'],
         },
@@ -540,6 +548,10 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               type: 'string',
               description: 'Mailbox to search (default: inbox)',
               default: 'inbox',
+            },
+            ascending: {
+              type: 'boolean',
+              description: 'Sort oldest first instead of newest first (default: false)',
             },
           },
         },
@@ -738,6 +750,10 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               type: 'number',
               description: 'Maximum results (default: 50)',
               default: 50,
+            },
+            ascending: {
+              type: 'boolean',
+              description: 'Sort oldest first instead of newest first (default: false)',
             },
           },
         },
@@ -943,9 +959,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'list_emails': {
-        const { mailboxId, limit } = args as any;
+        const { mailboxId, limit, ascending } = args as any;
         const validLimit = Math.min(Math.max(Number(limit) || 20, 1), 50);
-        const emails = await client.getEmails(mailboxId, validLimit);
+        const emails = await client.getEmails(mailboxId, validLimit, !!ascending);
         return {
           content: [
             {
@@ -1164,11 +1180,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'search_emails': {
-        const { query, limit = 20 } = args as any;
+        const { query, limit = 20, ascending } = args as any;
         if (!query) {
           throw new McpError(ErrorCode.InvalidParams, 'query is required');
         }
-        const emails = await client.searchEmails(query, limit);
+        const emails = await client.searchEmails(query, limit, !!ascending);
         return {
           content: [
             {
@@ -1316,9 +1332,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'get_recent_emails': {
-        const { limit = 10, mailboxName = 'inbox' } = args as any;
+        const { limit = 10, mailboxName = 'inbox', ascending } = args as any;
         const client = initializeClient();
-        const emails = await client.getRecentEmails(limit, mailboxName);
+        const emails = await client.getRecentEmails(limit, mailboxName, !!ascending);
         return {
           content: [
             {
@@ -1496,10 +1512,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'advanced_search': {
-        const { query, from, to, subject, hasAttachment, isUnread, isPinned, mailboxId, after, before, limit } = args as any;
+        const { query, from, to, subject, hasAttachment, isUnread, isPinned, mailboxId, after, before, limit, ascending } = args as any;
         const client = initializeClient();
         const emails = await client.advancedSearch({
-          query, from, to, subject, hasAttachment, isUnread, isPinned, mailboxId, after, before, limit
+          query, from, to, subject, hasAttachment, isUnread, isPinned, mailboxId, after, before, limit, ascending
         });
         return {
           content: [

--- a/src/jmap-client-extra.test.ts
+++ b/src/jmap-client-extra.test.ts
@@ -527,3 +527,102 @@ describe('getListResult', () => {
     assert.deepEqual(mailboxes, []);
   });
 });
+
+// ---------- ascending sort parameter ----------
+
+describe('ascending sort parameter', () => {
+  let client: JmapClient;
+
+  beforeEach(() => {
+    client = makeClient();
+  });
+
+  const QUERY_GET_RESPONSE = {
+    methodResponses: [
+      ['Email/query', { ids: ['e1'] }, 'query'],
+      ['Email/get', { list: [{ id: 'e1', subject: 'Test' }] }, 'emails'],
+    ],
+  };
+
+  describe('getEmails', () => {
+    it('defaults to isAscending: false', async () => {
+      const makeReq = mock.method(client, 'makeRequest', async () => QUERY_GET_RESPONSE);
+
+      await client.getEmails('mb-inbox', 5);
+
+      const sort = makeReq.mock.calls[0].arguments[0].methodCalls[0][1].sort;
+      assert.deepEqual(sort, [{ property: 'receivedAt', isAscending: false }]);
+    });
+
+    it('passes ascending=true as isAscending: true', async () => {
+      const makeReq = mock.method(client, 'makeRequest', async () => QUERY_GET_RESPONSE);
+
+      await client.getEmails('mb-inbox', 5, true);
+
+      const sort = makeReq.mock.calls[0].arguments[0].methodCalls[0][1].sort;
+      assert.deepEqual(sort, [{ property: 'receivedAt', isAscending: true }]);
+    });
+  });
+
+  describe('searchEmails', () => {
+    it('defaults to isAscending: false', async () => {
+      const makeReq = mock.method(client, 'makeRequest', async () => QUERY_GET_RESPONSE);
+
+      await client.searchEmails('test', 10);
+
+      const sort = makeReq.mock.calls[0].arguments[0].methodCalls[0][1].sort;
+      assert.deepEqual(sort, [{ property: 'receivedAt', isAscending: false }]);
+    });
+
+    it('passes ascending=true as isAscending: true', async () => {
+      const makeReq = mock.method(client, 'makeRequest', async () => QUERY_GET_RESPONSE);
+
+      await client.searchEmails('test', 10, true);
+
+      const sort = makeReq.mock.calls[0].arguments[0].methodCalls[0][1].sort;
+      assert.deepEqual(sort, [{ property: 'receivedAt', isAscending: true }]);
+    });
+  });
+
+  describe('getRecentEmails', () => {
+    it('defaults to isAscending: false', async () => {
+      stubMailboxes(client);
+      const makeReq = mock.method(client, 'makeRequest', async () => QUERY_GET_RESPONSE);
+
+      await client.getRecentEmails(10, 'inbox');
+
+      const sort = makeReq.mock.calls[0].arguments[0].methodCalls[0][1].sort;
+      assert.deepEqual(sort, [{ property: 'receivedAt', isAscending: false }]);
+    });
+
+    it('passes ascending=true as isAscending: true', async () => {
+      stubMailboxes(client);
+      const makeReq = mock.method(client, 'makeRequest', async () => QUERY_GET_RESPONSE);
+
+      await client.getRecentEmails(10, 'inbox', true);
+
+      const sort = makeReq.mock.calls[0].arguments[0].methodCalls[0][1].sort;
+      assert.deepEqual(sort, [{ property: 'receivedAt', isAscending: true }]);
+    });
+  });
+
+  describe('advancedSearch', () => {
+    it('defaults to isAscending: false when ascending not specified', async () => {
+      const makeReq = mock.method(client, 'makeRequest', async () => QUERY_GET_RESPONSE);
+
+      await client.advancedSearch({ query: 'test' });
+
+      const sort = makeReq.mock.calls[0].arguments[0].methodCalls[0][1].sort;
+      assert.deepEqual(sort, [{ property: 'receivedAt', isAscending: false }]);
+    });
+
+    it('passes ascending: true as isAscending: true', async () => {
+      const makeReq = mock.method(client, 'makeRequest', async () => QUERY_GET_RESPONSE);
+
+      await client.advancedSearch({ query: 'test', ascending: true });
+
+      const sort = makeReq.mock.calls[0].arguments[0].methodCalls[0][1].sort;
+      assert.deepEqual(sort, [{ property: 'receivedAt', isAscending: true }]);
+    });
+  });
+});

--- a/src/jmap-client.ts
+++ b/src/jmap-client.ts
@@ -135,18 +135,18 @@ export class JmapClient {
     return this.getListResult(response, 0);
   }
 
-  async getEmails(mailboxId?: string, limit: number = 20): Promise<any[]> {
+  async getEmails(mailboxId?: string, limit: number = 20, ascending: boolean = false): Promise<any[]> {
     const session = await this.getSession();
-    
+
     const filter = mailboxId ? { inMailbox: mailboxId } : {};
-    
+
     const request: JmapRequest = {
       using: ['urn:ietf:params:jmap:core', 'urn:ietf:params:jmap:mail'],
       methodCalls: [
         ['Email/query', {
           accountId: session.accountId,
           filter,
-          sort: [{ property: 'receivedAt', isAscending: false }],
+          sort: [{ property: 'receivedAt', isAscending: ascending }],
           limit
         }, 'query'],
         ['Email/get', {
@@ -691,7 +691,7 @@ export class JmapClient {
     return submissionId;
   }
 
-  async getRecentEmails(limit: number = 10, mailboxName: string = 'inbox'): Promise<any[]> {
+  async getRecentEmails(limit: number = 10, mailboxName: string = 'inbox', ascending: boolean = false): Promise<any[]> {
     const session = await this.getSession();
     
     // Find the specified mailbox (default to inbox)
@@ -711,7 +711,7 @@ export class JmapClient {
         ['Email/query', {
           accountId: session.accountId,
           filter: { inMailbox: targetMailbox.id },
-          sort: [{ property: 'receivedAt', isAscending: false }],
+          sort: [{ property: 'receivedAt', isAscending: ascending }],
           limit: Math.min(limit, 50)
         }, 'query'],
         ['Email/get', {
@@ -1110,6 +1110,7 @@ export class JmapClient {
     after?: string;
     before?: string;
     limit?: number;
+    ascending?: boolean;
   }): Promise<any[]> {
     const session = await this.getSession();
     
@@ -1147,7 +1148,7 @@ export class JmapClient {
         ['Email/query', {
           accountId: session.accountId,
           filter: finalFilter,
-          sort: [{ property: 'receivedAt', isAscending: false }],
+          sort: [{ property: 'receivedAt', isAscending: filters.ascending ?? false }],
           limit: Math.min(filters.limit || 50, 100)
         }, 'query'],
         ['Email/get', {
@@ -1162,7 +1163,7 @@ export class JmapClient {
     return this.getListResult(response, 1);
   }
 
-  async searchEmails(query: string, limit: number = 20): Promise<any[]> {
+  async searchEmails(query: string, limit: number = 20, ascending: boolean = false): Promise<any[]> {
     const session = await this.getSession();
 
     const request: JmapRequest = {
@@ -1171,7 +1172,7 @@ export class JmapClient {
         ['Email/query', {
           accountId: session.accountId,
           filter: { text: query },
-          sort: [{ property: 'receivedAt', isAscending: false }],
+          sort: [{ property: 'receivedAt', isAscending: ascending }],
           limit
         }, 'query'],
         ['Email/get', {


### PR DESCRIPTION
## Summary

Adds an `ascending` parameter to all four email list/search tools (`list_emails`, `search_emails`, `get_recent_emails`, `advanced_search`) to allow sorting oldest-first instead of the default newest-first.

Small change — one parameter per method, plumbed through to the JMAP `isAscending` sort option.

## Test plan

- [ ] `npm test` passes
- [ ] `list_emails` with `ascending: true` returns oldest first
- [ ] `search_emails` with `ascending: true` returns oldest first
- [ ] Default behavior (no param) unchanged — newest first