### PR TITLE
Feat: add replyTo parameter to email tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,13 +147,13 @@ You can install this server as a Desktop Extension for Claude Desktop using the 
 - **get_email**: Get a specific email by ID
   - Parameters: `emailId` (required)
 - **send_email**: Send an email (supports threading via optional `inReplyTo` and `references` headers)
-  - Parameters: `to` (required array), `cc` (optional array), `bcc` (optional array), `from` (optional), `mailboxId` (optional), `subject` (required), `textBody` (optional), `htmlBody` (optional), `inReplyTo` (optional array), `references` (optional array)
+  - Parameters: `to` (required array), `cc` (optional array), `bcc` (optional array), `from` (optional), `mailboxId` (optional), `subject` (required), `textBody` (optional), `htmlBody` (optional), `inReplyTo` (optional array), `references` (optional array), `replyTo` (optional array)
 - **reply_email**: Reply to an existing email with proper threading headers (automatically builds In-Reply-To and References). Set `send=false` to save as draft instead of sending.
-  - Parameters: `originalEmailId` (required), `to` (optional array, defaults to original sender), `cc` (optional array), `bcc` (optional array), `from` (optional), `textBody` (optional), `htmlBody` (optional), `send` (optional boolean, default: true)
+  - Parameters: `originalEmailId` (required), `to` (optional array, defaults to original sender), `cc` (optional array), `bcc` (optional array), `from` (optional), `textBody` (optional), `htmlBody` (optional), `send` (optional boolean, default: true), `replyTo` (optional array)
 - **save_draft**: Save an email as a draft without sending (supports threading headers for reply drafts)
   - Parameters: `to` (required array), `cc` (optional array), `bcc` (optional array), `from` (optional), `subject` (required), `textBody` (optional), `htmlBody` (optional), `inReplyTo` (optional array), `references` (optional array)
 - **create_draft**: Create a minimal email draft (at least one of to/subject/body required)
-  - Parameters: `to` (optional array), `cc` (optional array), `bcc` (optional array), `from` (optional), `mailboxId` (optional), `subject` (optional), `textBody` (optional), `htmlBody` (optional)
+  - Parameters: `to` (optional array), `cc` (optional array), `bcc` (optional array), `from` (optional), `mailboxId` (optional), `subject` (optional), `textBody` (optional), `htmlBody` (optional), `replyTo` (optional array)
 - **search_emails**: Search emails by content
   - Parameters: `query` (required), `limit` (default: 20)
 - **get_recent_emails**: Get the most recent emails from a mailbox (inspired by JMAP-Samples top-ten)

--- a/src/index.ts
+++ b/src/index.ts
@@ -204,6 +204,11 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               items: { type: 'string' },
               description: 'Full reference chain of Message-IDs (optional, for threading)',
             },
+            replyTo: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Reply-To email addresses (replies go here instead of to the sender)',
+            },
           },
           required: ['to', 'subject'],
         },
@@ -248,6 +253,11 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             send: {
               type: 'boolean',
               description: 'Whether to send the reply immediately (default: true). Set to false to save as draft instead.',
+            },
+            replyTo: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Reply-To email addresses (replies go here instead of to the sender)',
             },
           },
           required: ['originalEmailId'],
@@ -304,6 +314,11 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               items: { type: 'string' },
               description: 'Message-IDs for References header (optional, for threading)',
             },
+            replyTo: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Reply-To email addresses (replies go here instead of to the sender)',
+            },
           },
         },
       },
@@ -347,6 +362,11 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             htmlBody: {
               type: 'string',
               description: 'Updated HTML body (optional)',
+            },
+            replyTo: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Reply-To email addresses (replies go here instead of to the sender)',
             },
           },
           required: ['emailId'],
@@ -973,7 +993,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'send_email': {
-        const { to, cc, bcc, from, mailboxId, subject, textBody, htmlBody, inReplyTo, references } = args as any;
+        const { to, cc, bcc, from, mailboxId, subject, textBody, htmlBody, inReplyTo, references, replyTo } = args as any;
         if (!to || !Array.isArray(to) || to.length === 0) {
           throw new McpError(ErrorCode.InvalidParams, 'to field is required and must be a non-empty array');
         }
@@ -995,6 +1015,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           htmlBody,
           inReplyTo,
           references,
+          replyTo,
         });
 
         return {
@@ -1008,7 +1029,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'reply_email': {
-        const { originalEmailId, to, cc, bcc, from, textBody, htmlBody, send: shouldSend = true } = args as any;
+        const { originalEmailId, to, cc, bcc, from, textBody, htmlBody, send: shouldSend = true, replyTo } = args as any;
         if (!originalEmailId) {
           throw new McpError(ErrorCode.InvalidParams, 'originalEmailId is required');
         }
@@ -1038,16 +1059,16 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         }
 
         // Default recipients to the original sender
-        const replyTo = (to && Array.isArray(to) && to.length > 0)
+        const replyRecipients = (to && Array.isArray(to) && to.length > 0)
           ? to
           : (Array.isArray(originalEmail.from) ? originalEmail.from.map((addr: any) => addr.email).filter(Boolean) : []);
 
-        if (replyTo.length === 0) {
+        if (replyRecipients.length === 0) {
           throw new McpError(ErrorCode.InvalidParams, 'Could not determine reply recipient. Please provide "to" explicitly.');
         }
 
         const replyParams = {
-          to: replyTo,
+          to: replyRecipients,
           cc,
           bcc,
           from,
@@ -1056,6 +1077,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           htmlBody,
           inReplyTo: inReplyToHeader,
           references: referencesHeader,
+          replyTo,
         };
 
         if (!shouldSend) {
@@ -1083,7 +1105,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'create_draft': {
-        const { to, cc, bcc, from, mailboxId, subject, textBody, htmlBody, inReplyTo, references } = args as any;
+        const { to, cc, bcc, from, mailboxId, subject, textBody, htmlBody, inReplyTo, references, replyTo } = args as any;
 
         if (!to?.length && !subject && !textBody && !htmlBody) {
           throw new McpError(ErrorCode.InvalidParams, 'At least one of to, subject, textBody, or htmlBody must be provided');
@@ -1100,6 +1122,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           htmlBody,
           inReplyTo,
           references,
+          replyTo,
         });
 
         const summary = [
@@ -1120,7 +1143,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'edit_draft': {
-        const { emailId, to, cc, bcc, from, subject, textBody, htmlBody } = args as any;
+        const { emailId, to, cc, bcc, from, subject, textBody, htmlBody, replyTo } = args as any;
         if (!emailId) {
           throw new McpError(ErrorCode.InvalidParams, 'emailId is required');
         }
@@ -1133,6 +1156,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           subject,
           textBody,
           htmlBody,
+          replyTo,
         });
 
         return {

--- a/src/jmap-client.test.ts
+++ b/src/jmap-client.test.ts
@@ -591,3 +591,128 @@ describe('validateSavePath', () => {
     );
   });
 });
+
+// ---------- sendEmail replyTo ----------
+
+describe('sendEmail replyTo', () => {
+  let client: JmapClient;
+
+  beforeEach(() => {
+    client = makeClient();
+    mock.method(client, 'getMailboxes', async () => [
+      DRAFTS_MAILBOX,
+      { id: 'mb-sent', name: 'Sent', role: 'sent' },
+    ]);
+  });
+
+  it('includes replyTo in JMAP emailObject when provided', async () => {
+    const makeReq = mock.method(client, 'makeRequest', async () => ({
+      methodResponses: [
+        ['Email/set', { created: { draft: { id: 'email-new' } } }, 'createEmail'],
+        ['EmailSubmission/set', { created: { submission: { id: 'sub-1' } } }, 'submitEmail'],
+      ],
+    }));
+
+    await client.sendEmail({
+      to: ['bob@example.com'],
+      subject: 'Test',
+      textBody: 'Hello',
+      replyTo: ['other@example.com'],
+    });
+
+    const emailObj = makeReq.mock.calls[0].arguments[0].methodCalls[0][1].create.draft;
+    assert.deepEqual(emailObj.replyTo, [{ email: 'other@example.com' }]);
+  });
+
+  it('does NOT include replyTo when not provided', async () => {
+    const makeReq = mock.method(client, 'makeRequest', async () => ({
+      methodResponses: [
+        ['Email/set', { created: { draft: { id: 'email-new' } } }, 'createEmail'],
+        ['EmailSubmission/set', { created: { submission: { id: 'sub-1' } } }, 'submitEmail'],
+      ],
+    }));
+
+    await client.sendEmail({
+      to: ['bob@example.com'],
+      subject: 'Test',
+      textBody: 'Hello',
+    });
+
+    const emailObj = makeReq.mock.calls[0].arguments[0].methodCalls[0][1].create.draft;
+    assert.equal(emailObj.replyTo, undefined);
+  });
+});
+
+// ---------- createDraft replyTo ----------
+
+describe('createDraft replyTo', () => {
+  let client: JmapClient;
+
+  beforeEach(() => {
+    client = makeClient();
+  });
+
+  it('includes replyTo in created email object when provided', async () => {
+    const makeReq = mock.method(client, 'makeRequest', async () => ({
+      methodResponses: [
+        ['Email/set', { created: { draft: { id: 'email-draft' } } }, 'createDraft'],
+      ],
+    }));
+
+    await client.createDraft({
+      subject: 'Draft with replyTo',
+      replyTo: ['noreply@example.com'],
+    });
+
+    const emailObj = makeReq.mock.calls[0].arguments[0].methodCalls[0][1].create.draft;
+    assert.deepEqual(emailObj.replyTo, [{ email: 'noreply@example.com' }]);
+  });
+});
+
+// ---------- updateDraft replyTo ----------
+
+describe('updateDraft replyTo', () => {
+  let client: JmapClient;
+
+  beforeEach(() => {
+    client = makeClient();
+  });
+
+  it('overrides existing replyTo when provided in updates', async () => {
+    const existingWithReplyTo = {
+      ...EXISTING_DRAFT,
+      replyTo: [{ email: 'old-reply@example.com' }],
+    };
+
+    const makeReq = mock.method(client, 'makeRequest', async (req: any) => {
+      if (req.methodCalls[0][0] === 'Email/get') {
+        return { methodResponses: [['Email/get', { list: [existingWithReplyTo] }, 'getEmail']] };
+      }
+      return { methodResponses: [['Email/set', { created: { draft: { id: 'draft-new' } }, destroyed: ['draft-1'] }, 'updateDraft']] };
+    });
+
+    await client.updateDraft('draft-1', { replyTo: ['new-reply@example.com'] });
+
+    const emailObj = makeReq.mock.calls[1].arguments[0].methodCalls[0][1].create.draft;
+    assert.deepEqual(emailObj.replyTo, [{ email: 'new-reply@example.com' }]);
+  });
+
+  it('preserves existing replyTo when not provided in updates', async () => {
+    const existingWithReplyTo = {
+      ...EXISTING_DRAFT,
+      replyTo: [{ email: 'keep-me@example.com' }],
+    };
+
+    const makeReq = mock.method(client, 'makeRequest', async (req: any) => {
+      if (req.methodCalls[0][0] === 'Email/get') {
+        return { methodResponses: [['Email/get', { list: [existingWithReplyTo] }, 'getEmail']] };
+      }
+      return { methodResponses: [['Email/set', { created: { draft: { id: 'draft-new' } }, destroyed: ['draft-1'] }, 'updateDraft']] };
+    });
+
+    await client.updateDraft('draft-1', { subject: 'Updated subject only' });
+
+    const emailObj = makeReq.mock.calls[1].arguments[0].methodCalls[0][1].create.draft;
+    assert.deepEqual(emailObj.replyTo, [{ email: 'keep-me@example.com' }]);
+  });
+});

--- a/src/jmap-client.ts
+++ b/src/jmap-client.ts
@@ -152,7 +152,7 @@ export class JmapClient {
         ['Email/get', {
           accountId: session.accountId,
           '#ids': { resultOf: 'query', name: 'Email/query', path: '/ids' },
-          properties: ['id', 'subject', 'from', 'to', 'receivedAt', 'preview', 'hasAttachment']
+          properties: ['id', 'subject', 'from', 'to', 'replyTo', 'receivedAt', 'preview', 'hasAttachment']
         }, 'emails']
       ]
     };
@@ -170,7 +170,7 @@ export class JmapClient {
         ['Email/get', {
           accountId: session.accountId,
           ids: [id],
-          properties: ['id', 'subject', 'from', 'to', 'cc', 'bcc', 'receivedAt', 'textBody', 'htmlBody', 'attachments', 'bodyValues', 'messageId', 'threadId', 'inReplyTo', 'references'],
+          properties: ['id', 'subject', 'from', 'to', 'cc', 'bcc', 'replyTo', 'receivedAt', 'textBody', 'htmlBody', 'attachments', 'bodyValues', 'messageId', 'threadId', 'inReplyTo', 'references'],
           bodyProperties: ['partId', 'blobId', 'type', 'size'],
           fetchTextBodyValues: true,
           fetchHTMLBodyValues: true,
@@ -227,6 +227,7 @@ export class JmapClient {
     mailboxId?: string;
     inReplyTo?: string[];
     references?: string[];
+    replyTo?: string[];
   }): Promise<string> {
     const session = await this.getSession();
 
@@ -289,6 +290,7 @@ export class JmapClient {
       subject: email.subject,
       ...(email.inReplyTo && { inReplyTo: email.inReplyTo }),
       ...(email.references && { references: email.references }),
+      ...(email.replyTo?.length && { replyTo: email.replyTo.map(addr => ({ email: addr })) }),
       textBody: email.textBody ? [{ partId: 'text', type: 'text/plain' }] : undefined,
       htmlBody: email.htmlBody ? [{ partId: 'html', type: 'text/html' }] : undefined,
       bodyValues: {
@@ -364,6 +366,7 @@ export class JmapClient {
     mailboxId?: string;
     inReplyTo?: string[];
     references?: string[];
+    replyTo?: string[];
   }): Promise<string> {
     const session = await this.getSession();
 
@@ -420,6 +423,7 @@ export class JmapClient {
     if (email.subject) emailObject.subject = email.subject;
     if (email.inReplyTo?.length) emailObject.inReplyTo = email.inReplyTo;
     if (email.references?.length) emailObject.references = email.references;
+    if (email.replyTo?.length) emailObject.replyTo = email.replyTo.map(addr => ({ email: addr }));
     if (email.textBody) emailObject.textBody = [{ partId: 'text', type: 'text/plain' }];
     if (email.htmlBody) emailObject.htmlBody = [{ partId: 'html', type: 'text/html' }];
     if (email.textBody || email.htmlBody) {
@@ -466,6 +470,7 @@ export class JmapClient {
     textBody?: string;
     htmlBody?: string;
     from?: string;
+    replyTo?: string[];
   }): Promise<string> {
     const session = await this.getSession();
 
@@ -476,7 +481,7 @@ export class JmapClient {
         ['Email/get', {
           accountId: session.accountId,
           ids: [emailId],
-          properties: ['id', 'subject', 'from', 'to', 'cc', 'bcc', 'textBody', 'htmlBody', 'bodyValues', 'mailboxIds', 'keywords'],
+          properties: ['id', 'subject', 'from', 'to', 'cc', 'bcc', 'replyTo', 'textBody', 'htmlBody', 'bodyValues', 'mailboxIds', 'keywords'],
           bodyProperties: ['partId', 'blobId', 'type', 'size'],
           fetchTextBodyValues: true,
           fetchHTMLBodyValues: true,
@@ -538,6 +543,7 @@ export class JmapClient {
     const mergedTo = updates.to !== undefined ? updates.to.map(addr => ({ email: addr })) : (existingEmail.to || []);
     const mergedCc = updates.cc !== undefined ? updates.cc.map(addr => ({ email: addr })) : (existingEmail.cc || []);
     const mergedBcc = updates.bcc !== undefined ? updates.bcc.map(addr => ({ email: addr })) : (existingEmail.bcc || []);
+    const mergedReplyTo = updates.replyTo !== undefined ? updates.replyTo.map(addr => ({ email: addr })) : (existingEmail.replyTo || null);
 
     const textBodyValue = updates.textBody !== undefined ? updates.textBody : (existingTextBody as any)?.value;
     const htmlBodyValue = updates.htmlBody !== undefined ? updates.htmlBody : (existingHtmlBody as any)?.value;
@@ -550,6 +556,7 @@ export class JmapClient {
       cc: mergedCc,
       bcc: mergedBcc,
       subject: mergedSubject,
+      ...(mergedReplyTo?.length && { replyTo: mergedReplyTo }),
     };
 
     if (textBodyValue) emailObject.textBody = [{ partId: 'text', type: 'text/plain' }];
@@ -599,7 +606,7 @@ export class JmapClient {
         ['Email/get', {
           accountId: session.accountId,
           ids: [emailId],
-          properties: ['id', 'from', 'to', 'cc', 'bcc', 'keywords'],
+          properties: ['id', 'from', 'to', 'cc', 'bcc', 'replyTo', 'keywords'],
         }, 'getEmail']
       ]
     };
@@ -717,7 +724,7 @@ export class JmapClient {
         ['Email/get', {
           accountId: session.accountId,
           '#ids': { resultOf: 'query', name: 'Email/query', path: '/ids' },
-          properties: ['id', 'subject', 'from', 'to', 'receivedAt', 'preview', 'hasAttachment', 'keywords']
+          properties: ['id', 'subject', 'from', 'to', 'replyTo', 'receivedAt', 'preview', 'hasAttachment', 'keywords']
         }, 'emails']
       ]
     };
@@ -1153,7 +1160,7 @@ export class JmapClient {
         ['Email/get', {
           accountId: session.accountId,
           '#ids': { resultOf: 'query', name: 'Email/query', path: '/ids' },
-          properties: ['id', 'subject', 'from', 'to', 'cc', 'receivedAt', 'preview', 'hasAttachment', 'keywords', 'threadId']
+          properties: ['id', 'subject', 'from', 'to', 'cc', 'replyTo', 'receivedAt', 'preview', 'hasAttachment', 'keywords', 'threadId']
         }, 'emails']
       ]
     };
@@ -1177,7 +1184,7 @@ export class JmapClient {
         ['Email/get', {
           accountId: session.accountId,
           '#ids': { resultOf: 'query', name: 'Email/query', path: '/ids' },
-          properties: ['id', 'subject', 'from', 'to', 'receivedAt', 'preview', 'hasAttachment']
+          properties: ['id', 'subject', 'from', 'to', 'replyTo', 'receivedAt', 'preview', 'hasAttachment']
         }, 'emails']
       ]
     };
@@ -1226,7 +1233,7 @@ export class JmapClient {
         ['Email/get', {
           accountId: session.accountId,
           '#ids': { resultOf: 'getThread', name: 'Thread/get', path: '/list/*/emailIds' },
-          properties: ['id', 'subject', 'from', 'to', 'cc', 'receivedAt', 'preview', 'hasAttachment', 'keywords', 'threadId']
+          properties: ['id', 'subject', 'from', 'to', 'cc', 'replyTo', 'receivedAt', 'preview', 'hasAttachment', 'keywords', 'threadId']
         }, 'emails']
       ]
     };


### PR DESCRIPTION
## Summary

Fixes #37 — adds an optional `replyTo` parameter to `send_email`, `reply_email`, `create_draft`, and `edit_draft`.

Maps directly to JMAP's `replyTo` property (RFC 8621 `EmailAddress[]`). Allows sending from one address while having replies go to another — common for assistant/delegate workflows.

No behavioral change for callers who omit it.

## Test plan

- [ ] `npm test` passes
- [ ] `send_email` with `replyTo: ["other@example.com"]` — sent email has Reply-To header
- [ ] `create_draft` with `replyTo` — draft includes the field
- [ ] `edit_draft` preserves existing `replyTo` when not provided, updates it when provided
- [ ] `reply_email` with `replyTo` — reply has Reply-To header