### PR TITLE
Fix: create_calendar_event silently fails for timezone offsets

### DIFF
--- a/src/caldav-client.test.ts
+++ b/src/caldav-client.test.ts
@@ -6,6 +6,9 @@ import {
   formatICalDate,
   parseCalendarObject,
   escapeICalText,
+  unescapeICalText,
+  toICalUTC,
+  foldICalLine,
   CalDAVCalendarClient,
 } from './caldav-client.js';
 
@@ -223,6 +226,140 @@ describe('parseCalendarObject', () => {
     assert.equal(event.description, undefined);
     assert.equal(event.location, undefined);
     assert.equal(event.end, undefined);
+  });
+});
+
+describe('toICalUTC', () => {
+  it('converts timezone offset to UTC', () => {
+    assert.equal(toICalUTC('2026-04-07T18:45:00+10:00'), '20260407T084500Z');
+  });
+
+  it('converts negative timezone offset to UTC', () => {
+    assert.equal(toICalUTC('2026-04-07T08:45:00-05:00'), '20260407T134500Z');
+  });
+
+  it('handles UTC input (Z suffix)', () => {
+    assert.equal(toICalUTC('2026-04-07T08:45:00Z'), '20260407T084500Z');
+  });
+
+  it('preserves floating time (no offset) without converting to UTC', () => {
+    assert.equal(toICalUTC('2026-04-07T18:45:00'), '20260407T184500');
+  });
+
+  it('throws on invalid date input', () => {
+    assert.throws(() => toICalUTC('not-a-date'), /Invalid date: not-a-date/);
+  });
+
+  it('handles midnight boundary crossing', () => {
+    assert.equal(toICalUTC('2026-04-07T23:55:00+12:00'), '20260407T115500Z');
+  });
+});
+
+describe('foldICalLine', () => {
+  it('returns short lines unchanged', () => {
+    assert.equal(foldICalLine('SUMMARY:Short'), 'SUMMARY:Short');
+  });
+
+  it('folds lines longer than 75 octets', () => {
+    const long = 'DESCRIPTION:' + 'x'.repeat(80);
+    const folded = foldICalLine(long);
+    const lines = folded.split('\r\n');
+    assert.ok(Buffer.byteLength(lines[0], 'utf8') <= 75);
+    assert.ok(lines[1].startsWith(' '));
+  });
+
+  it('folds very long lines into multiple segments', () => {
+    const long = 'DESCRIPTION:' + 'y'.repeat(200);
+    const folded = foldICalLine(long);
+    const lines = folded.split('\r\n');
+    assert.ok(lines.length >= 3);
+    for (let i = 1; i < lines.length; i++) {
+      assert.ok(lines[i].startsWith(' '));
+    }
+  });
+
+  it('keeps every segment within 75 octets', () => {
+    const long = 'DESCRIPTION:' + 'z'.repeat(200);
+    const folded = foldICalLine(long);
+    const lines = folded.split('\r\n');
+    for (const line of lines) {
+      assert.ok(Buffer.byteLength(line, 'utf8') <= 75);
+    }
+  });
+
+  it('folds multi-byte characters without exceeding 75 octets', () => {
+    const long = 'LOCATION:' + '📍'.repeat(20);
+    const folded = foldICalLine(long);
+    const lines = folded.split('\r\n');
+    assert.ok(lines.length >= 2);
+    for (const line of lines) {
+      assert.ok(Buffer.byteLength(line, 'utf8') <= 75,
+        `Line exceeds 75 octets: ${Buffer.byteLength(line, 'utf8')} bytes`);
+    }
+  });
+});
+
+describe('unescapeICalText', () => {
+  it('unescapes literal \\n to newline', () => {
+    assert.equal(unescapeICalText('Line one\\nLine two'), 'Line one\nLine two');
+  });
+
+  it('unescapes commas', () => {
+    assert.equal(unescapeICalText('Room A\\, Building 1'), 'Room A, Building 1');
+  });
+
+  it('unescapes semicolons', () => {
+    assert.equal(unescapeICalText('a\\;b\\;c'), 'a;b;c');
+  });
+
+  it('unescapes backslashes', () => {
+    assert.equal(unescapeICalText('path\\\\to\\\\file'), 'path\\to\\file');
+  });
+
+  it('round-trips with escapeICalText', () => {
+    const original = 'Meet; discuss, plan\nPath\\to\\file';
+    assert.equal(unescapeICalText(escapeICalText(original)), original);
+  });
+
+  it('handles literal backslash followed by n (not a newline)', () => {
+    assert.equal(unescapeICalText('\\\\n'), '\\n');
+  });
+
+  it('handles literal backslash followed by comma', () => {
+    assert.equal(unescapeICalText('\\\\,'), '\\,');
+  });
+});
+
+describe('iCal create/parse round-trip', () => {
+  it('round-trips special characters through create and parse', () => {
+    const title = 'Meeting; discuss, plan';
+    const description = 'Line one\nLine two\nPath\\to\\file; note, important';
+    const location = 'Room A, Building 1; Floor 2';
+
+    const uid = 'test-roundtrip@fastmail-mcp';
+    const now = '20260407T000000Z';
+    const ical = [
+      'BEGIN:VCALENDAR',
+      'VERSION:2.0',
+      'PRODID:-//fastmail-mcp//CalDAV//EN',
+      'BEGIN:VEVENT',
+      `UID:${uid}`,
+      `DTSTAMP:${now}`,
+      `DTSTART:${toICalUTC('2026-04-07T18:45:00+10:00')}`,
+      `DTEND:${toICalUTC('2026-04-07T20:00:00+10:00')}`,
+      foldICalLine(`SUMMARY:${escapeICalText(title)}`),
+      foldICalLine(`DESCRIPTION:${escapeICalText(description)}`),
+      foldICalLine(`LOCATION:${escapeICalText(location)}`),
+      'END:VEVENT',
+      'END:VCALENDAR',
+    ].filter(Boolean).join('\r\n');
+
+    const event = parseCalendarObject({ data: ical, url: 'https://example.com/cal/test.ics' });
+    assert.equal(event.title, title);
+    assert.equal(event.description, description);
+    assert.equal(event.location, location);
+    assert.equal(event.start, '2026-04-07T08:45:00Z');
+    assert.equal(event.end, '2026-04-07T10:00:00Z');
   });
 });
 

--- a/src/caldav-client.ts
+++ b/src/caldav-client.ts
@@ -92,6 +92,45 @@ export function formatICalDate(raw: string | undefined): string | undefined {
   return cleaned;
 }
 
+/**
+ * Convert an ISO 8601 datetime string to iCalendar UTC format.
+ * Handles timezone offsets by converting to UTC via Date.
+ * Preserves floating times (no offset, no Z) as-is.
+ * e.g. "2026-04-07T18:45:00+10:00" → "20260407T084500Z"
+ */
+export function toICalUTC(isoString: string): string {
+  // Floating time (no offset, no Z) — preserve as local iCal datetime
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/.test(isoString)) {
+    return isoString.replace(/[-:]/g, '');
+  }
+  const d = new Date(isoString);
+  if (isNaN(d.getTime())) throw new Error(`Invalid date: ${isoString}`);
+  return d.toISOString().replace(/[-:]/g, '').replace(/\.\d{3}/, '');
+}
+
+/**
+ * Fold an iCalendar content line at 75 octets per RFC 5545 §3.1.
+ */
+export function foldICalLine(line: string): string {
+  const parts: string[] = [];
+  while (Buffer.byteLength(line, 'utf8') > 75) {
+    // Find the largest character count that fits in 75 bytes
+    let cut = 75;
+    while (cut > 0 && Buffer.byteLength(line.slice(0, cut), 'utf8') > 75) {
+      cut--;
+    }
+    // Don't split a surrogate pair (characters outside BMP like emoji)
+    if (cut > 0 && cut < line.length) {
+      const code = line.charCodeAt(cut);
+      if (code >= 0xDC00 && code <= 0xDFFF) cut--;
+    }
+    parts.push(line.slice(0, cut));
+    line = ' ' + line.slice(cut);
+  }
+  parts.push(line);
+  return parts.join('\r\n');
+}
+
 export function parseCalendarObject(obj: DAVCalendarObject): CalendarEvent {
   const vevent = extractVEvent(obj.data || '');
   const title = parseICalValue(vevent, 'SUMMARY') || 'Untitled';
@@ -117,11 +156,12 @@ export function parseCalendarObject(obj: DAVCalendarObject): CalendarEvent {
  * Reverses escaping of newlines, semicolons, commas, and backslashes.
  */
 export function unescapeICalText(value: string): string {
-  return value
-    .replace(/\\n/gi, '\n')
-    .replace(/\\;/g, ';')
-    .replace(/\\,/g, ',')
-    .replace(/\\\\/g, '\\');
+  return value.replace(/\\(\\|;|,|[nN])/g, (_, ch) => {
+    if (ch === 'n' || ch === 'N') return '\n';
+    if (ch === ',') return ',';
+    if (ch === ';') return ';';
+    return '\\';
+  });
 }
 
 /**
@@ -268,11 +308,11 @@ export class CalDAVCalendarClient {
       'BEGIN:VEVENT',
       `UID:${uid}`,
       `DTSTAMP:${now}`,
-      `DTSTART:${event.start.replace(/[-:]/g, '')}`,
-      `DTEND:${event.end.replace(/[-:]/g, '')}`,
-      `SUMMARY:${escapeICalText(event.title)}`,
-      event.description ? `DESCRIPTION:${escapeICalText(event.description)}` : '',
-      event.location ? `LOCATION:${escapeICalText(event.location)}` : '',
+      `DTSTART:${toICalUTC(event.start)}`,
+      `DTEND:${toICalUTC(event.end)}`,
+      foldICalLine(`SUMMARY:${escapeICalText(event.title)}`),
+      event.description ? foldICalLine(`DESCRIPTION:${escapeICalText(event.description)}`) : '',
+      event.location ? foldICalLine(`LOCATION:${escapeICalText(event.location)}`) : '',
       'END:VEVENT',
       'END:VCALENDAR',
     ].filter(Boolean).join('\r\n');


### PR DESCRIPTION
## Summary

`create_calendar_event` returns a success response with a UID, but the event is never persisted on the CalDAV server when the input datetime includes a timezone offset (e.g. `+10:00`). No error is thrown.

**Root cause:** The naive `event.start.replace(/[-:]/g, '')` strips colons from timezone offsets, producing `DTSTART:20260407T184500+1000` — which is not a valid iCalendar datetime form (RFC 5545 §3.3.5 requires UTC with `Z`, floating, or `TZID` parameter). The server silently rejects the PUT while `tsdav` does not throw.

This PR also fixes two related iCalendar encoding issues:

- **No line folding:** Long SUMMARY/DESCRIPTION/LOCATION values exceeded 75 octets per line, violating RFC 5545 §3.1
- **`unescapeICalText` ordering bug:** The sequential `.replace()` chain incorrectly decodes `\n` (escaped backslash + letter n) as a newline instead of `\n`. This is an interop issue — it corrupts text when parsing events created by other CalDAV clients (Apple Calendar, Thunderbird, etc.) that correctly escape literal backslashes per RFC 5545 §3.3.11

## Changes

- Add `toICalUTC()` — converts ISO 8601 offset datetimes to UTC, preserves floating times
- Add `foldICalLine()` — folds content lines at 75 UTF-8 octets with surrogate pair safety
- Fix `unescapeICalText()` — single-pass regex avoids ordering ambiguity between `\` and `\n`
- Update `createCalendarEvent` to use `toICalUTC` and `foldICalLine`

## Test plan

- [x] 6 tests for `toICalUTC` (positive/negative offsets, UTC, floating, invalid input, boundary crossing)
- [x] 5 tests for `foldICalLine` (short passthrough, basic fold, multi-segment, 75-octet enforcement, multi-byte emoji)
- [x] 7 tests for `unescapeICalText` (basic unescaping, round-trip with `escapeICalText`, `\n` and `\,` edge cases)
- [x] 1 end-to-end round-trip test (create iCal → parse back → verify all fields survive)
- [x] All 48 CalDAV tests pass
- [x] Functionally tested against live Fastmail CalDAV server — event persists and reads back correctly