### PR TITLE
Chore: remove dead code, cap search limits, add version sync test

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -997,7 +997,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       case 'list_emails': {
         const { mailboxId, limit, ascending } = args as any;
-        const validLimit = Math.min(Math.max(Number(limit) || 20, 1), 50);
+        const validLimit = Math.min(Math.max(Number(limit) || 20, 1), 100);
         const emails = await client.getEmails(mailboxId, validLimit, !!ascending);
         return {
           content: [
@@ -1221,11 +1221,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'search_emails': {
-        const { query, limit = 20, ascending } = args as any;
+        const { query, limit, ascending } = args as any;
         if (!query) {
           throw new McpError(ErrorCode.InvalidParams, 'query is required');
         }
-        const emails = await client.searchEmails(query, limit, !!ascending);
+        const validLimit = Math.min(Math.max(Number(limit) || 20, 1), 100);
+        const emails = await client.searchEmails(query, validLimit, !!ascending);
         return {
           content: [
             {
@@ -1555,8 +1556,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case 'advanced_search': {
         const { query, from, to, subject, hasAttachment, isUnread, isPinned, mailboxId, after, before, limit, ascending } = args as any;
         const client = initializeClient();
+        const validLimit = Math.min(Math.max(Number(limit) || 50, 1), 100);
         const emails = await client.advancedSearch({
-          query, from, to, subject, hasAttachment, isUnread, isPinned, mailboxId, after, before, limit, ascending
+          query, from, to, subject, hasAttachment, isUnread, isPinned, mailboxId, after, before, limit: validLimit, ascending
         });
         return {
           content: [

--- a/src/jmap-client.test.ts
+++ b/src/jmap-client.test.ts
@@ -744,3 +744,23 @@ describe('updateDraft replyTo', () => {
     assert.deepEqual(emailObj.replyTo, [{ email: 'keep-me@example.com' }]);
   });
 });
+
+// ---------- version sync ----------
+
+describe('version sync', () => {
+  it('package.json, manifest.json, and index.ts all have the same version', async () => {
+    const { readFileSync } = await import('fs');
+    const { resolve: r } = await import('path');
+    const root = r(import.meta.dirname, '..');
+
+    const pkg = JSON.parse(readFileSync(r(root, 'package.json'), 'utf8'));
+    const manifest = JSON.parse(readFileSync(r(root, 'manifest.json'), 'utf8'));
+    const indexSrc = readFileSync(r(root, 'src', 'index.ts'), 'utf8');
+
+    const indexMatch = indexSrc.match(/version:\s*'([^']+)'/);
+    assert.ok(indexMatch, 'Could not find version string in index.ts');
+
+    assert.equal(pkg.version, manifest.version, 'package.json and manifest.json versions must match');
+    assert.equal(pkg.version, indexMatch[1], 'package.json and index.ts versions must match');
+  });
+});

--- a/src/jmap-client.ts
+++ b/src/jmap-client.ts
@@ -86,16 +86,6 @@ export class JmapClient {
     return this.session;
   }
 
-  async getUserEmail(): Promise<string> {
-    try {
-      const identity = await this.getDefaultIdentity();
-      return identity?.email || 'user@example.com';
-    } catch (error) {
-      // Fallback if Identity/get is not available
-      return 'user@example.com';
-    }
-  }
-
   async makeRequest(request: JmapRequest): Promise<JmapResponse> {
     const session = await this.getSession();
     
@@ -447,13 +437,13 @@ export class JmapClient {
 
     const result = this.getMethodResult(response, 0);
 
-    // Bug 2: Propagate server-provided error details from notCreated
+    // Propagate server-provided error details from notCreated
     if (result.notCreated?.draft) {
       const err = result.notCreated.draft;
       throw new Error(`Failed to create draft: ${err.type}${err.description ? ' - ' + err.description : ''}`);
     }
 
-    // Bug 3: Throw if created ID is missing instead of returning 'unknown'
+    // Throw if created ID is missing instead of returning silently
     const emailId = result.created?.draft?.id;
     if (!emailId) {
       throw new Error('Draft creation returned no email ID');


### PR DESCRIPTION
## Summary

- Remove unused `getUserEmail()` method from jmap-client
- Clean up leftover development comments ("Bug N" markers)
- Cap `list_emails` limit at 100 (was 50), `search_emails` and `advanced_search` at 100 (were uncapped)
- Add test verifying version string stays in sync across `package.json`, `manifest.json`, and `src/index.ts`

## Test plan

- [x] Version sync test passes
- [x] All existing tests pass
- [x] No references to removed `getUserEmail()` remain