### PR TITLE
Fix: support wildcard identities in from address validation

### DIFF
--- a/src/jmap-client.test.ts
+++ b/src/jmap-client.test.ts
@@ -187,6 +187,51 @@ describe('createDraft', () => {
     );
   });
 
+  // 8b. Wildcard identity matches concrete from address
+  it('matches wildcard identity for from address', async () => {
+    const wildcardIdentity = { id: 'id-wild', email: '*@example.com', mayDelete: true };
+    mock.method(client, 'getIdentities', async () => [wildcardIdentity]);
+
+    const makeReq = mock.method(client, 'makeRequest', async () => ({
+      methodResponses: [
+        ['Email/set', { created: { draft: { id: 'email-wild' } } }, 'createDraft'],
+      ],
+    }));
+
+    await client.createDraft({ subject: 'Hi', from: 'work@example.com' });
+
+    const emailObj = makeReq.mock.calls[0].arguments[0].methodCalls[0][1].create.draft;
+    assert.deepEqual(emailObj.from, [{ email: 'work@example.com' }]);
+  });
+
+  // 8c. Bare @ rejected (no local part)
+  it('rejects bare @ address against wildcard identity', async () => {
+    const wildcardIdentity = { id: 'id-wild', email: '*@example.com', mayDelete: true };
+    mock.method(client, 'getIdentities', async () => [wildcardIdentity]);
+
+    await assert.rejects(
+      () => client.createDraft({ subject: 'Hi', from: '@example.com' }),
+      (err: Error) => {
+        assert.match(err.message, /not verified/i);
+        return true;
+      },
+    );
+  });
+
+  // 8d. Wildcard identity does not match different domain
+  it('rejects from address that does not match wildcard domain', async () => {
+    const wildcardIdentity = { id: 'id-wild', email: '*@example.com', mayDelete: true };
+    mock.method(client, 'getIdentities', async () => [wildcardIdentity]);
+
+    await assert.rejects(
+      () => client.createDraft({ subject: 'Hi', from: 'work@other.com' }),
+      (err: Error) => {
+        assert.match(err.message, /not verified/i);
+        return true;
+      },
+    );
+  });
+
   // 9. Custom mailboxId used instead of auto-lookup
   it('uses provided mailboxId without looking up mailboxes', async () => {
     const getMailboxes = client.getMailboxes as ReturnType<typeof mock.method>;
@@ -742,5 +787,110 @@ describe('updateDraft replyTo', () => {
 
     const emailObj = makeReq.mock.calls[1].arguments[0].methodCalls[0][1].create.draft;
     assert.deepEqual(emailObj.replyTo, [{ email: 'keep-me@example.com' }]);
+  });
+});
+
+// ---------- wildcard identity ----------
+
+const WILDCARD_IDENTITY = { id: 'id-wild', name: 'Jonathan Godley', email: '*@example.com', mayDelete: true };
+
+describe('sendEmail wildcard identity', () => {
+  let client: JmapClient;
+
+  beforeEach(() => {
+    client = makeClient();
+    mock.method(client, 'getIdentities', async () => [WILDCARD_IDENTITY]);
+    mock.method(client, 'getMailboxes', async () => [
+      DRAFTS_MAILBOX,
+      { id: 'mb-sent', name: 'Sent', role: 'sent' },
+    ]);
+  });
+
+  it('uses concrete from address in email and envelope, not wildcard literal', async () => {
+    const makeReq = mock.method(client, 'makeRequest', async () => ({
+      methodResponses: [
+        ['Email/set', { created: { draft: { id: 'email-new' } } }, 'createEmail'],
+        ['EmailSubmission/set', { created: { submission: { id: 'sub-1' } } }, 'submitEmail'],
+      ],
+    }));
+
+    await client.sendEmail({
+      to: ['bob@example.com'],
+      subject: 'Test',
+      textBody: 'Hello',
+      from: 'work@example.com',
+    });
+
+    const req = makeReq.mock.calls[0].arguments[0];
+    const emailObj = req.methodCalls[0][1].create.draft;
+    assert.deepEqual(emailObj.from, [{ name: 'Jonathan Godley', email: 'work@example.com' }]);
+    const envelope = req.methodCalls[1][1].create.submission.envelope;
+    assert.deepEqual(envelope.mailFrom, { email: 'work@example.com' });
+  });
+});
+
+describe('sendDraft wildcard identity', () => {
+  let client: JmapClient;
+
+  beforeEach(() => {
+    client = makeClient();
+    mock.method(client, 'getIdentities', async () => [WILDCARD_IDENTITY]);
+    mock.method(client, 'getMailboxes', async () => [DRAFTS_MAILBOX, SENT_MAILBOX]);
+  });
+
+  it('matches wildcard identity when draft has concrete from address', async () => {
+    const wildcardDraft = { ...SENDABLE_DRAFT, from: [{ email: 'work@example.com' }] };
+    const makeReq = mock.method(client, 'makeRequest', async (req: any) => {
+      if (req.methodCalls[0][0] === 'Email/get') {
+        return { methodResponses: [['Email/get', { list: [wildcardDraft] }, 'getEmail']] };
+      }
+      return { methodResponses: [['EmailSubmission/set', { created: { submission: { id: 'sub-1' } } }, 'submitDraft']] };
+    });
+
+    const subId = await client.sendDraft('draft-1');
+    assert.equal(subId, 'sub-1');
+
+    const submitCall = makeReq.mock.calls[1].arguments[0];
+    assert.equal(submitCall.methodCalls[0][1].create.submission.identityId, WILDCARD_IDENTITY.id);
+    assert.deepEqual(submitCall.methodCalls[0][1].create.submission.envelope.mailFrom, { email: 'work@example.com' });
+  });
+});
+
+describe('updateDraft wildcard identity', () => {
+  let client: JmapClient;
+
+  beforeEach(() => {
+    client = makeClient();
+    mock.method(client, 'getIdentities', async () => [WILDCARD_IDENTITY]);
+  });
+
+  it('uses concrete from address when updating with wildcard identity', async () => {
+    const existingWild = { ...EXISTING_DRAFT, from: [{ email: 'old@example.com' }] };
+    const makeReq = mock.method(client, 'makeRequest', async (req: any) => {
+      if (req.methodCalls[0][0] === 'Email/get') {
+        return { methodResponses: [['Email/get', { list: [existingWild] }, 'getEmail']] };
+      }
+      return { methodResponses: [['Email/set', { created: { draft: { id: 'draft-2' } }, destroyed: ['draft-1'] }, 'updateDraft']] };
+    });
+
+    await client.updateDraft('draft-1', { from: 'new@example.com' });
+
+    const emailObj = makeReq.mock.calls[1].arguments[0].methodCalls[0][1].create.draft;
+    assert.deepEqual(emailObj.from, [{ email: 'new@example.com' }]);
+  });
+
+  it('preserves concrete from when updating without changing from', async () => {
+    const existingWild = { ...EXISTING_DRAFT, from: [{ email: 'work@example.com' }] };
+    const makeReq = mock.method(client, 'makeRequest', async (req: any) => {
+      if (req.methodCalls[0][0] === 'Email/get') {
+        return { methodResponses: [['Email/get', { list: [existingWild] }, 'getEmail']] };
+      }
+      return { methodResponses: [['Email/set', { created: { draft: { id: 'draft-2' } }, destroyed: ['draft-1'] }, 'updateDraft']] };
+    });
+
+    await client.updateDraft('draft-1', { subject: 'Changed subject only' });
+
+    const emailObj = makeReq.mock.calls[1].arguments[0].methodCalls[0][1].create.draft;
+    assert.deepEqual(emailObj.from, [{ email: 'work@example.com' }]);
   });
 });

--- a/src/jmap-client.ts
+++ b/src/jmap-client.ts
@@ -21,6 +21,17 @@ export interface JmapResponse {
   sessionState: string;
 }
 
+/** Match an email address against an identity, supporting wildcard identities (e.g. *@example.com). */
+function matchesIdentity(identityEmail: string, address: string): boolean {
+  const identity = identityEmail.toLowerCase();
+  const addr = address.toLowerCase();
+  if (identity === addr) return true;
+  if (identity.startsWith('*@')) {
+    const domain = identity.slice(1); // "@example.com"
+    return addr.endsWith(domain) && addr.indexOf('@') > 0;
+  }
+  return false;
+}
 export class JmapClient {
   private auth: FastmailAuth;
   private session: JmapSession | null = null;
@@ -241,9 +252,7 @@ export class JmapClient {
     let selectedIdentity;
     if (email.from) {
       // Validate that the from address matches an available identity
-      selectedIdentity = identities.find(id => 
-        id.email.toLowerCase() === email.from?.toLowerCase()
-      );
+      selectedIdentity = identities.find(id => matchesIdentity(id.email, email.from!));
       if (!selectedIdentity) {
         throw new Error('From address is not verified for sending. Choose one of your verified identities.');
       }
@@ -252,7 +261,8 @@ export class JmapClient {
       selectedIdentity = identities.find(id => id.mayDelete === false) || identities[0];
     }
 
-    const fromEmail = selectedIdentity.email;
+    // Use the requested from address (not the identity email, which may be a wildcard like *@domain)
+    const fromEmail = email.from || selectedIdentity.email;
 
     // Get the mailbox IDs we need
     const mailboxes = await this.getMailboxes();
@@ -383,9 +393,7 @@ export class JmapClient {
 
     let selectedIdentity;
     if (email.from) {
-      selectedIdentity = identities.find(id =>
-        id.email.toLowerCase() === email.from?.toLowerCase()
-      );
+      selectedIdentity = identities.find(id => matchesIdentity(id.email, email.from!));
       if (!selectedIdentity) {
         throw new Error('From address is not verified for sending. Choose one of your verified identities.');
       }
@@ -393,7 +401,7 @@ export class JmapClient {
       selectedIdentity = identities.find(id => id.mayDelete === false) || identities[0];
     }
 
-    const fromEmail = selectedIdentity.email;
+    const fromEmail = email.from || selectedIdentity.email;
 
     // Resolve drafts mailbox
     let draftMailboxId: string;
@@ -508,9 +516,7 @@ export class JmapClient {
 
     let selectedIdentity;
     if (updates.from) {
-      selectedIdentity = identities.find(id =>
-        id.email.toLowerCase() === updates.from?.toLowerCase()
-      );
+      selectedIdentity = identities.find(id => matchesIdentity(id.email, updates.from!));
       if (!selectedIdentity) {
         throw new Error('From address is not verified for sending. Choose one of your verified identities.');
       }
@@ -518,9 +524,8 @@ export class JmapClient {
       // Use existing from, or fall back to default identity
       const existingFrom = existingEmail.from?.[0]?.email;
       if (existingFrom) {
-        selectedIdentity = identities.find(id =>
-          id.email.toLowerCase() === existingFrom.toLowerCase()
-        ) || identities.find(id => id.mayDelete === false) || identities[0];
+        selectedIdentity = identities.find(id => matchesIdentity(id.email, existingFrom))
+          || identities.find(id => id.mayDelete === false) || identities[0];
       } else {
         selectedIdentity = identities.find(id => id.mayDelete === false) || identities[0];
       }
@@ -551,7 +556,7 @@ export class JmapClient {
     const emailObject: any = {
       mailboxIds: existingEmail.mailboxIds,
       keywords: { $draft: true },
-      from: [{ email: selectedIdentity.email }],
+      from: [{ email: updates.from || existingEmail.from?.[0]?.email || selectedIdentity.email }],
       to: mergedTo,
       cc: mergedCc,
       bcc: mergedBcc,
@@ -639,9 +644,7 @@ export class JmapClient {
     }
 
     const identities = await this.getIdentities();
-    const selectedIdentity = identities.find(id =>
-      id.email.toLowerCase() === fromEmail.toLowerCase()
-    );
+    const selectedIdentity = identities.find(id => matchesIdentity(id.email, fromEmail));
     if (!selectedIdentity) {
       throw new Error('From address on draft does not match any sending identity');
     }


### PR DESCRIPTION
## Summary

Fixes #46.

Fastmail supports wildcard sending identities (e.g. `*@example.com`), but identity resolution used strict string equality, so any concrete `from` address like `work@example.com` was rejected with "From address is not verified".

- Added `matchesIdentity()` helper that checks exact match first, then wildcard domain match (with guard against bare `@` addresses)
- Applied to all 5 identity lookup sites: `sendEmail`, `createDraft`, `updateDraft` (2 sites), `sendDraft`
- `sendEmail` and `createDraft` now use the user's requested `from` address in the email object, not the identity's literal `*@domain`
- `updateDraft` preserves the existing concrete `from` when not explicitly changed

## Test plan

- [x] `createDraft` with wildcard identity uses concrete from address
- [x] `createDraft` rejects bare `@` address against wildcard
- [x] `createDraft` rejects from address on different domain than wildcard
- [x] `sendEmail` with wildcard: email object and SMTP envelope both use concrete address
- [x] `sendDraft` with wildcard: matches identity and uses concrete from in envelope
- [x] `updateDraft` with explicit from: uses new concrete address
- [x] `updateDraft` without from change: preserves existing concrete address
- [x] All existing tests pass