### PR TITLE
Fix: sendEmail envelope missing cc/bcc recipients

### DIFF
--- a/src/jmap-client.test.ts
+++ b/src/jmap-client.test.ts
@@ -671,6 +671,64 @@ describe('sendEmail replyTo', () => {
   });
 });
 
+// ---------- sendEmail envelope recipients ----------
+
+describe('sendEmail envelope recipients', () => {
+  let client: JmapClient;
+
+  beforeEach(() => {
+    client = makeClient();
+    mock.method(client, 'getMailboxes', async () => [
+      DRAFTS_MAILBOX,
+      { id: 'mb-sent', name: 'Sent', role: 'sent' },
+    ]);
+  });
+
+  it('includes to, cc, and bcc in envelope rcptTo', async () => {
+    const makeReq = mock.method(client, 'makeRequest', async () => ({
+      methodResponses: [
+        ['Email/set', { created: { draft: { id: 'email-new' } } }, 'createEmail'],
+        ['EmailSubmission/set', { created: { submission: { id: 'sub-1' } } }, 'submitEmail'],
+      ],
+    }));
+
+    await client.sendEmail({
+      to: ['alice@example.com'],
+      cc: ['bob@example.com'],
+      bcc: ['charlie@example.com'],
+      subject: 'Test',
+      textBody: 'Hello',
+    });
+
+    const req = makeReq.mock.calls[0].arguments[0];
+    const rcptTo = req.methodCalls[1][1].create.submission.envelope.rcptTo;
+    assert.equal(rcptTo.length, 3);
+    assert.deepEqual(rcptTo[0], { email: 'alice@example.com' });
+    assert.deepEqual(rcptTo[1], { email: 'bob@example.com' });
+    assert.deepEqual(rcptTo[2], { email: 'charlie@example.com' });
+  });
+
+  it('works with only to recipients (no cc/bcc)', async () => {
+    const makeReq = mock.method(client, 'makeRequest', async () => ({
+      methodResponses: [
+        ['Email/set', { created: { draft: { id: 'email-new' } } }, 'createEmail'],
+        ['EmailSubmission/set', { created: { submission: { id: 'sub-1' } } }, 'submitEmail'],
+      ],
+    }));
+
+    await client.sendEmail({
+      to: ['alice@example.com'],
+      subject: 'Test',
+      textBody: 'Hello',
+    });
+
+    const req = makeReq.mock.calls[0].arguments[0];
+    const rcptTo = req.methodCalls[1][1].create.submission.envelope.rcptTo;
+    assert.equal(rcptTo.length, 1);
+    assert.deepEqual(rcptTo[0], { email: 'alice@example.com' });
+  });
+});
+
 // ---------- createDraft replyTo ----------
 
 describe('createDraft replyTo', () => {

--- a/src/jmap-client.ts
+++ b/src/jmap-client.ts
@@ -314,7 +314,11 @@ export class JmapClient {
               identityId: selectedIdentity.id,
               envelope: {
                 mailFrom: { email: fromEmail },
-                rcptTo: email.to.map(addr => ({ email: addr }))
+                rcptTo: [
+                  ...email.to.map(addr => ({ email: addr })),
+                  ...(email.cc || []).map(addr => ({ email: addr })),
+                  ...(email.bcc || []).map(addr => ({ email: addr })),
+                ]
               }
             }
           },


### PR DESCRIPTION
## Summary

The SMTP envelope `rcptTo` in `sendEmail` only included `to` recipients. Since the code explicitly provides an `envelope` in the `EmailSubmission/set` call, the server uses exactly what's given rather than deriving it from headers (per RFC 8621 §7). This means cc and bcc addresses appeared in the email headers but were not included in the SMTP envelope — recipients on cc/bcc would not receive the email.

The fix adds cc and bcc to the `rcptTo` array, matching the existing correct behaviour in `sendDraft` (which already includes all three recipient types).

Note: In SMTP (RFC 5321), `RCPT TO` is a flat list of all recipients — there is no distinction between to, cc, and bcc at the envelope level. That distinction only exists in the email headers. Bcc recipients are included in `RCPT TO` but excluded from headers before delivery.

## Test plan

- [x] `sendEmail` with to + cc + bcc: all three appear in envelope `rcptTo`
- [x] `sendEmail` with only to: works correctly (no crash from missing cc/bcc)
- [x] All existing tests pass