### PR TITLE
fix: default get_recent_emails to search all mail instead of inbox-only

### DIFF
--- a/src/jmap-client.ts
+++ b/src/jmap-client.ts
@@ -698,18 +698,22 @@ export class JmapClient {
     return submissionId;
   }
 
-  async getRecentEmails(limit: number = 10, mailboxName: string = 'inbox', ascending: boolean = false): Promise<any[]> {
+  async getRecentEmails(limit: number = 10, mailboxName: string | null = null, ascending: boolean = false): Promise<any[]> {
     const session = await this.getSession();
-    
-    // Find the specified mailbox (default to inbox)
-    const mailboxes = await this.getMailboxes();
-    const targetMailbox = mailboxes.find(mb => 
-      mb.role === mailboxName.toLowerCase() || 
-      mb.name.toLowerCase().includes(mailboxName.toLowerCase())
-    );
-    
-    if (!targetMailbox) {
-      throw new Error(`Could not find mailbox: ${mailboxName}`);
+
+    // When mailboxName is null or empty, search all mail (no inMailbox filter).
+    // When a mailbox name is provided, resolve it and restrict the query to that mailbox.
+    let filter: any = {};
+    if (mailboxName) {
+      const mailboxes = await this.getMailboxes();
+      const targetMailbox = mailboxes.find(mb =>
+        mb.role === mailboxName.toLowerCase() ||
+        mb.name.toLowerCase().includes(mailboxName.toLowerCase())
+      );
+      if (!targetMailbox) {
+        throw new Error(`Could not find mailbox: ${mailboxName}`);
+      }
+      filter = { inMailbox: targetMailbox.id };
     }
 
     const request: JmapRequest = {
@@ -717,7 +721,7 @@ export class JmapClient {
       methodCalls: [
         ['Email/query', {
           accountId: session.accountId,
-          filter: { inMailbox: targetMailbox.id },
+          filter,
           sort: [{ property: 'receivedAt', isAscending: ascending }],
           limit: Math.min(limit, 50)
         }, 'query'],


### PR DESCRIPTION
## What was the bug

The `getRecentEmails` function had `mailboxName = 'inbox'` as its default parameter. This meant that any call without an explicit mailbox silently restricted results to the inbox folder only — emails in Sent, Drafts, Spam, or any custom folder were invisible.

This behavior was never documented, so from a user or MCP tool perspective, asking for \"recent emails\" and only getting inbox results felt like missing mail with no explanation.

## Real-world impact

- An MCP tool calling `get_recent_emails` with no mailbox argument would miss everything outside the inbox
- Emails you sent (Sent folder), drafts, or mail in custom folders would never appear
- No error is raised — the function just quietly returns a partial view of your mailbox

## What changed

**In `src/jmap-client.ts`:**

- Changed the default for `mailboxName` from `'inbox'` to `null`
- When `mailboxName` is `null` (the new default), the `inMailbox` filter is omitted entirely, so JMAP returns mail across all folders
- When `mailboxName` is provided (e.g. `'inbox'`, `'sent'`, or any custom name), the filter is applied exactly as before

## Backward compatibility

Fully backward compatible. Any caller that was already passing `'inbox'` explicitly gets identical behavior. The only change is the no-argument default: instead of silently scoping to inbox, it now searches all mail — which is almost certainly what users expect when they don't specify a folder.

## Testing

Verified the TypeScript compiles cleanly with `npm run build` after the change.