### PR TITLE
Add targeted mailbox lookup, creation, and slim enumeration

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -133,10 +133,52 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
     tools: [
       {
         name: 'list_mailboxes',
-        description: 'List all mailboxes in the Fastmail account',
+        description: 'List mailboxes in the Fastmail account. By default returns all mailboxes with full metadata; on accounts with hundreds of mailboxes the full result can exceed the MCP tool result window. Use `properties: ["id","name","parentId"]` for a slim view, and/or `parentId` to filter to one level of children.',
         inputSchema: {
           type: 'object',
-          properties: {},
+          properties: {
+            properties: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'JMAP Mailbox properties to return (e.g. ["id","name","parentId"]). Default: all properties. The slim form roughly halves payload size on large accounts.',
+            },
+            parentId: {
+              type: ['string', 'null'],
+              description: 'Filter to direct children of this mailbox ID. Pass null for top-level mailboxes. Filter is applied client-side after Mailbox/get.',
+            },
+          },
+        },
+      },
+      {
+        name: 'get_mailbox_by_name',
+        description: 'Look up a single mailbox by its full path from root (e.g. "Folder/Subfolder/Leaf"). Returns the mailbox ID and minimal metadata, or throws "Mailbox not found" if no exact match. The path separator is "/"; folder names containing a literal "/" are not supported.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            path: {
+              type: 'string',
+              description: 'Full path from root, separated by "/" (e.g. "Inbox" or "Archive/2026/Suppliers/ExampleCo").',
+            },
+          },
+          required: ['path'],
+        },
+      },
+      {
+        name: 'create_mailbox',
+        description: 'Create a new mailbox (folder). Returns the new mailbox ID. The caller is responsible for validating the name is appropriate (length, character set, parent-folder allow-list) before calling — JMAP itself only enforces uniqueness within a parent.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string',
+              description: 'Leaf name of the new mailbox (not a full path). Must not contain "/".',
+            },
+            parentId: {
+              type: ['string', 'null'],
+              description: 'Parent mailbox ID. Pass null (or omit) to create at top level.',
+            },
+          },
+          required: ['name'],
         },
       },
       {
@@ -995,12 +1037,55 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     switch (name) {
       case 'list_mailboxes': {
-        const mailboxes = await client.getMailboxes();
+        const { properties, parentId } = (args ?? {}) as any;
+        const options: { properties?: string[]; parentId?: string | null } = {};
+        if (Array.isArray(properties) && properties.length > 0) {
+          options.properties = properties;
+        }
+        if (args && Object.prototype.hasOwnProperty.call(args, 'parentId')) {
+          options.parentId = parentId ?? null;
+        }
+        const mailboxes = await client.getMailboxes(options);
         return {
           content: [
             {
               type: 'text',
               text: JSON.stringify(mailboxes, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'get_mailbox_by_name': {
+        const { path } = (args ?? {}) as any;
+        if (!path || typeof path !== 'string') {
+          throw new McpError(ErrorCode.InvalidParams, 'path is required and must be a non-empty string');
+        }
+        const mailbox = await client.getMailboxByName(path);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(mailbox, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'create_mailbox': {
+        const { name: mailboxName, parentId } = (args ?? {}) as any;
+        if (!mailboxName || typeof mailboxName !== 'string') {
+          throw new McpError(ErrorCode.InvalidParams, 'name is required and must be a non-empty string');
+        }
+        if (mailboxName.includes('/')) {
+          throw new McpError(ErrorCode.InvalidParams, 'name must not contain "/" — pass a leaf name and use parentId to nest');
+        }
+        const newId = await client.createMailbox(mailboxName, parentId ?? null);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({ id: newId, name: mailboxName, parentId: parentId ?? null }, null, 2),
             },
           ],
         };
@@ -1752,7 +1837,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           email: {
             available: true,
             functions: [
-              'list_mailboxes', 'list_emails', 'get_email', 'send_email', 'create_draft', 'edit_draft', 'send_draft', 'search_emails',
+              'list_mailboxes', 'get_mailbox_by_name', 'create_mailbox', 'list_emails', 'get_email', 'send_email',
+              'create_draft', 'edit_draft', 'send_draft', 'search_emails',
               'get_recent_emails', 'mark_email_read', 'pin_email', 'delete_email', 'move_email',
               'get_email_attachments', 'download_attachment', 'advanced_search', 'get_thread',
               'get_mailbox_stats', 'get_account_summary', 'bulk_mark_read', 'bulk_pin', 'bulk_move', 'bulk_delete',

--- a/src/jmap-client.ts
+++ b/src/jmap-client.ts
@@ -139,18 +139,94 @@ export class JmapClient {
            (nameFallback ? mailboxes.find(mb => mb.name.toLowerCase().includes(nameFallback)) : undefined);
   }
 
-  async getMailboxes(): Promise<any[]> {
+  async getMailboxes(options?: { properties?: string[]; parentId?: string | null }): Promise<any[]> {
     const session = await this.getSession();
-    
+
+    const args: Record<string, any> = { accountId: session.accountId };
+    if (options?.properties && options.properties.length > 0) {
+      args.properties = options.properties;
+    }
+
     const request: JmapRequest = {
       using: ['urn:ietf:params:jmap:core', 'urn:ietf:params:jmap:mail'],
       methodCalls: [
-        ['Mailbox/get', { accountId: session.accountId }, 'mailboxes']
+        ['Mailbox/get', args, 'mailboxes']
       ]
     };
 
     const response = await this.makeRequest(request);
-    return this.getListResult(response, 0);
+    let list = this.getListResult(response, 0);
+    if (options && Object.prototype.hasOwnProperty.call(options, 'parentId')) {
+      const filterParent = options.parentId ?? null;
+      list = list.filter((mb: any) => (mb.parentId ?? null) === filterParent);
+    }
+    return list;
+  }
+
+  async getMailboxByName(path: string): Promise<{ id: string; name: string; parentId: string | null; path: string }> {
+    if (!path || typeof path !== 'string') {
+      throw new Error('path is required and must be a non-empty string');
+    }
+    const mailboxes = await this.getMailboxes({ properties: ['id', 'name', 'parentId'] });
+    const byId = new Map<string, any>();
+    for (const mb of mailboxes) byId.set(mb.id, mb);
+
+    const buildPath = (mb: any): string => {
+      const segments: string[] = [];
+      let cursor: any = mb;
+      let depth = 0;
+      while (cursor && depth < 100) {
+        segments.unshift(cursor.name);
+        cursor = cursor.parentId ? byId.get(cursor.parentId) : null;
+        depth++;
+      }
+      return segments.join('/');
+    };
+
+    for (const mb of mailboxes) {
+      if (buildPath(mb) === path) {
+        return { id: mb.id, name: mb.name, parentId: mb.parentId ?? null, path };
+      }
+    }
+    throw new Error(`Mailbox not found: ${path}`);
+  }
+
+  async createMailbox(name: string, parentId?: string | null): Promise<string> {
+    if (!name || typeof name !== 'string') {
+      throw new Error('name is required and must be a non-empty string');
+    }
+    const session = await this.getSession();
+
+    const request: JmapRequest = {
+      using: ['urn:ietf:params:jmap:core', 'urn:ietf:params:jmap:mail'],
+      methodCalls: [
+        ['Mailbox/set', {
+          accountId: session.accountId,
+          create: {
+            new1: {
+              name,
+              parentId: parentId ?? null
+            }
+          }
+        }, 'createMailbox']
+      ]
+    };
+
+    const response = await this.makeRequest(request);
+    const result = this.getMethodResult(response, 0);
+
+    if (result.notCreated && result.notCreated.new1) {
+      const err = result.notCreated.new1;
+      const detail = err.description ? ` - ${err.description}` : '';
+      const props = err.properties ? ` (properties: ${err.properties.join(', ')})` : '';
+      throw new Error(`Failed to create mailbox: ${err.type}${detail}${props}`);
+    }
+
+    const created = result.created?.new1;
+    if (!created?.id) {
+      throw new Error('Mailbox creation reported success but server did not return an ID');
+    }
+    return created.id;
   }
 
   async getEmails(mailboxId?: string, limit: number = 20, ascending: boolean = false): Promise<any[]> {


### PR DESCRIPTION
While building a Claude Code skill on top of fastmail-mcp I bumped into three small rough edges in the mailbox area. They're all little, they all use plumbing the MCP already has, and they pair naturally — so one PR felt friendlier than three.

The thing that started this: on a real account with 220+ mailboxes, `list_mailboxes` returns ~210KB of JSON and trips over the MCP tool-result window. The other two are capabilities I found I wanted once the skill grew — looking up a mailbox by path when I know the folder I want but not its id, and creating a new mailbox when the skill decides to file mail into a fresh subfolder.

Three additions, all built on `Mailbox/get` and `Mailbox/set`:

- **`get_mailbox_by_name(path)`** — walks the parentId chain client-side and returns `{id, name, parentId, path}` for an exact match, or throws "Mailbox not found". Path separator is `/`; folder names containing a literal `/` aren't supported (documented).

- **`list_mailboxes`** now accepts optional `properties` and `parentId`: `properties: ["id","name","parentId"]` roughly halves payload size, and `parentId` filters to direct children client-side. Backwards compatible — called with no args it returns all properties as before, so existing callers don't need to change.

- **`create_mailbox(name, parentId)`** — wraps `Mailbox/set` create and surfaces the JMAP error type/description on failure (e.g. a duplicate name). The `/` check is enforced in the tool handler so callers can't accidentally smuggle a path; structural rules (length, character set, parent allow-list) are deliberately left to the caller, since they vary by use case.

Smoke-tested against the same 220+ mailbox account that started this: `get_mailbox_by_name` resolved a deep path correctly, the slim `list_mailboxes` returned 148 children of one parent without overflow, and `create_mailbox` produced an id that immediately accepted a `move_email`.

`check_function_availability` has been updated to list the two new tools so its report stays accurate. All 176 existing unit tests pass.

---
This PR was drafted with Claude Opus 4.7; I reviewed and tested each commit before opening.