### PR TITLE
Add get_email_metadata — headers-only Email/get for least-privilege flows

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -176,6 +176,20 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         },
       },
       {
+        name: 'get_email_metadata',
+        description: 'Get headers/metadata for an email — sender, recipients, subject, date, threading, mailbox membership, keywords (read/flagged/etc.), size, and whether an attachment is present — but NOT the body, preview, or any rendered text. Useful when a workflow needs to classify or route an email without ingesting its content (e.g. customer-mail least-privilege flows where reading bodies is forbidden, or skills that only need to verify post-archive folder placement). The return shape is the standard JMAP Email object restricted to a strict header-only allowlist.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            emailId: {
+              type: 'string',
+              description: 'ID of the email to retrieve metadata for',
+            },
+          },
+          required: ['emailId'],
+        },
+      },
+      {
         name: 'send_email',
         description: 'Send an email',
         inputSchema: {
@@ -1036,6 +1050,22 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
       }
 
+      case 'get_email_metadata': {
+        const { emailId } = (args ?? {}) as any;
+        if (!emailId) {
+          throw new McpError(ErrorCode.InvalidParams, 'emailId is required');
+        }
+        const email = await client.getEmailMetadata(emailId);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(email, null, 2),
+            },
+          ],
+        };
+      }
+
       case 'send_email': {
         const { to, cc, bcc, from, mailboxId, subject, textBody, htmlBody, inReplyTo, references, replyTo } = args as any;
         const toArray = coerceStringArray(to);
@@ -1752,7 +1782,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           email: {
             available: true,
             functions: [
-              'list_mailboxes', 'list_emails', 'get_email', 'send_email', 'create_draft', 'edit_draft', 'send_draft', 'search_emails',
+              'list_mailboxes', 'list_emails', 'get_email', 'get_email_metadata', 'send_email', 'create_draft', 'edit_draft', 'send_draft', 'search_emails',
               'get_recent_emails', 'mark_email_read', 'pin_email', 'delete_email', 'move_email',
               'get_email_attachments', 'download_attachment', 'advanced_search', 'get_thread',
               'get_mailbox_stats', 'get_account_summary', 'bulk_mark_read', 'bulk_pin', 'bulk_move', 'bulk_delete',

--- a/src/jmap-client.ts
+++ b/src/jmap-client.ts
@@ -207,7 +207,54 @@ export class JmapClient {
     if (!email) {
       throw new Error(`Email with ID '${id}' not found or not accessible`);
     }
-    
+
+    return email;
+  }
+
+  async getEmailMetadata(id: string): Promise<any> {
+    const session = await this.getSession();
+
+    const request: JmapRequest = {
+      using: ['urn:ietf:params:jmap:core', 'urn:ietf:params:jmap:mail'],
+      methodCalls: [
+        ['Email/get', {
+          accountId: session.accountId,
+          ids: [id],
+          properties: [
+            'id',
+            'threadId',
+            'mailboxIds',
+            'keywords',
+            'receivedAt',
+            'sentAt',
+            'subject',
+            'from',
+            'to',
+            'cc',
+            'bcc',
+            'replyTo',
+            'messageId',
+            'inReplyTo',
+            'references',
+            'size',
+            'hasAttachment',
+          ],
+        }, 'emailMetadata']
+      ]
+    };
+
+    const response = await this.makeRequest(request);
+    const result = this.getMethodResult(response, 0);
+
+    if (result.notFound && result.notFound.includes(id)) {
+      throw new Error(`Email with ID '${id}' not found`);
+    }
+
+    const email = result.list?.[0];
+    if (!email) {
+      throw new Error(`Email with ID '${id}' not found or not accessible`);
+    }
+
     return email;
   }
 


### PR DESCRIPTION
The existing `get_email` tool returns the full Email object — `textBody`, `htmlBody`, `bodyValues`, `attachments` — which is great for "show me this email" workflows but a hammer-too-large for skills that just need to classify or route based on headers.

This shows up most acutely in privacy-sensitive flows: a skill working through a customer-mail mailbox might be specifically forbidden from ingesting message bodies (GDPR / least-privilege rules), but still needs the basic envelope data — sender, subject, date, mailbox membership — to do its job. With only `get_email` available, the skill has to either (a) take the full payload and remember to discard the body in its prompt logic, or (b) work around using `advanced_search` filters. Both approaches put the privacy guarantee in the wrong place: in the caller's discipline rather than the tool surface.

`get_email_metadata` is a tool-level guarantee. It calls `Email/get` with a strict `properties` allowlist:

```
id, threadId, mailboxIds, keywords, receivedAt, sentAt, subject,
from, to, cc, bcc, replyTo, messageId, inReplyTo, references,
size, hasAttachment
```

There's no `bodyProperties`, no `fetchTextBodyValues`, no `fetchHTMLBodyValues` — the JMAP server simply never sends body content in this tool's path. `hasAttachment` is a Boolean (yes/no); filenames and content types deliberately aren't surfaced because filenames sometimes carry PII (`Smith Invoice June 2026.pdf`-style leakage). If a caller does need attachment metadata or to download attachments, `get_email_attachments` and `download_attachment` cover that explicitly.

Useful side benefit: this tool returns `mailboxIds`, which the existing `get_email` omits. That makes `get_email_metadata` the right call for "verify this email landed in the expected folder after I moved it" checks — handy in tests and skill self-assessment paths.

Smoke-tested: response carries the 17 expected keys and none of `textBody` / `htmlBody` / `bodyValues` / `body` / `preview` / `attachments`. The existing `get_email` on the same email returns `attachments`, `bodyValues`, `htmlBody`, `textBody` — confirming the contrast. All 176 existing unit tests still pass.

---
This PR was drafted with Claude Opus 4.7; I reviewed and tested each commit before opening.