### PR TITLE
Raise per-tool result size limit on get_email to 500KB

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -174,6 +174,18 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           },
           required: ['emailId'],
         },
+        _meta: {
+          // Raise the per-tool result size limit honoured by Claude Code
+          // (v2.1.91+) and other MCP clients that respect this annotation.
+          // get_email returns the full Email object including textBody/
+          // htmlBody/bodyValues/attachments — promotional newsletters and
+          // policy-update emails routinely exceed the default ~25KB inline
+          // budget and get spilled to a temp file by the harness, which
+          // then forces the caller to do its own file-read recovery.
+          // 500000 chars (~500KB) covers virtually all real-world email
+          // payloads while remaining well under the MCP hard ceiling.
+          'anthropic/maxResultSizeChars': 500000,
+        },
       },
       {
         name: 'send_email',


### PR DESCRIPTION
While building a Claude Code skill on top of fastmail-mcp I noticed `get_email` was hitting the MCP harness's auto-spill behaviour on entirely normal email payloads. HTML bodies above ~25KB (the default `MAX_MCP_OUTPUT_TOKENS` budget for inline tool results) get written to `/tmp/<tool>_<timestamp>.md` and the model receives only a file path. The caller then has to do its own `Read` + `JSON.parse` recovery to get at the body — and clean up the temp file afterwards if it cares about not leaving raw mail content on disk.

Promotional newsletters, policy-update emails, and onboarding emails routinely exceed 25KB. On a real account I hit a 44KB Argos privacy-policy email and a ~60KB Fastmail import-completion email that both spilled on `get_email` — entirely usable payloads that didn't need the indirection.

Claude Code v2.1.91+ honours an `_meta: { "anthropic/maxResultSizeChars": <N> }` annotation on individual tool definitions to override the default. This adds the annotation to `get_email` with N=500000 (~500KB), which covers virtually every real email without going near the MCP hard ceiling. Other clients that don't recognise the annotation simply ignore it — `_meta` is the standardised escape hatch for client-specific hints — so there's no compatibility risk for users on older clients or different MCP hosts.

Smoke-tested locally on Claude Code v2.1.126: a 44KB Argos email that previously spilled now comes back inline. All 176 existing unit tests still pass.

Scope is intentionally narrow to just `get_email` — that's the tool where the spill was observed. `get_thread` and the listing tools could plausibly hit the same limit on threads or result-sets with many large preview fields, but those deserve their own PRs once a real case shows up.

Reference: https://code.claude.com/docs/en/mcp.md#raise-the-limit-for-a-specific-tool

---
This PR was drafted with Claude Opus 4.7; I reviewed and tested each commit before opening.