### PR TITLE
Fix: report calendar available when CalDAV is configured (#76)

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ You can install this server as a Desktop Extension for Claude Desktop using the 
 ### Identity & Testing Tools
 
 - **list_identities**: List sending identities (email addresses that can be used for sending)
-- **check_function_availability**: Check which functions are available based on account permissions (includes setup guidance)
+- **check_function_availability**: Check which functions are available based on account permissions (includes setup guidance). Calendar tools run over CalDAV, so calendar is reported available when CalDAV credentials are configured, regardless of the JMAP calendar capability.
 - **test_bulk_operations**: Safely test bulk operations with dry-run mode
   - Parameters: `dryRun` (default: true), `limit` (default: 3)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -957,7 +957,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: 'check_function_availability',
-        description: 'Check which MCP functions are available based on account permissions',
+        description: 'Check which MCP functions are available based on account permissions. Calendar tools run over CalDAV, so calendar is reported available when CalDAV credentials are configured, regardless of the JMAP calendar capability.',
         inputSchema: {
           type: 'object',
           properties: {},
@@ -1747,7 +1747,19 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case 'check_function_availability': {
         const client = initializeClient();
         const session = await client.getSession();
-        
+
+        // Calendar tools run on CalDAV, not JMAP. So calendar is available if
+        // EITHER the JMAP calendar capability is present OR CalDAV credentials
+        // are configured (FASTMAIL_CALDAV_USERNAME / FASTMAIL_CALDAV_PASSWORD).
+        const jmapCalendar = !!session.capabilities['urn:ietf:params:jmap:calendars'];
+        const caldavConfigured = initializeCalDAVClient() !== null;
+        const calendarAvailable = jmapCalendar || caldavConfigured;
+        const calendarNote = jmapCalendar
+          ? 'Calendar is available (JMAP)'
+          : caldavConfigured
+            ? 'Calendar is available via CalDAV'
+            : 'Calendar access not available - set FASTMAIL_CALDAV_USERNAME and FASTMAIL_CALDAV_PASSWORD, or enable calendar scope in Fastmail account settings';
+
         const availability = {
           email: {
             available: true,
@@ -1780,14 +1792,13 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             }
           },
           calendar: {
-            available: !!session.capabilities['urn:ietf:params:jmap:calendars'],
+            available: calendarAvailable,
             functions: ['list_calendars', 'list_calendar_events', 'get_calendar_event', 'create_calendar_event'],
-            note: session.capabilities['urn:ietf:params:jmap:calendars'] ? 
-              'Calendar is available' : 
-              'Calendar access not available - may require enabling in Fastmail account settings',
-            enablementGuide: session.capabilities['urn:ietf:params:jmap:calendars'] ? null : {
+            note: calendarNote,
+            enablementGuide: calendarAvailable ? null : {
               steps: [
-                '1. Log into Fastmail web interface',
+                'Option A (CalDAV): set FASTMAIL_CALDAV_USERNAME and FASTMAIL_CALDAV_PASSWORD (app password) — calendar tools run over CalDAV',
+                'Option B (JMAP scope): 1. Log into Fastmail web interface',
                 '2. Go to Settings → Privacy & Security → Connected Apps & API tokens',
                 '3. Check if calendar scope is enabled for your API token',
                 '4. If not available, you may need to upgrade your Fastmail plan or contact support'


### PR DESCRIPTION
## Summary

`check_function_availability` reports calendar as unavailable for accounts that have CalDAV configured but lack the JMAP `urn:ietf:params:jmap:calendars` capability — even though the calendar tools (`list_calendars`, `list_calendar_events`, `get_calendar_event`, `create_calendar_event`) run over CalDAV and work fine. Reported in #76.

## Fix

Calendar availability is now `JMAP calendar capability OR CalDAV configured` (`initializeCalDAVClient() !== null`). The `note` reflects which backend is active (JMAP / CalDAV / neither), and the enablement guide is shown only when neither path is available — now mentioning the CalDAV option as well as the JMAP scope steps.

## Scope

- `src/index.ts` — `check_function_availability` handler + tool description
- `README.md` — tool reference note

No other behavior changes; no version bump.

## Testing

- `npx tsc --noEmit` clean.
- `npm test` passes except for two pre-existing symlink-escape tests that require Windows elevation in my environment (unrelated to this change; they fail identically on a pristine `main`).
- Manual: with only `FASTMAIL_CALDAV_USERNAME` / `FASTMAIL_CALDAV_PASSWORD` set and no JMAP calendar scope, `check_function_availability` now reports calendar `available: true` with a "Calendar is available via CalDAV" note.

Closes #76.
