### PR TITLE
Resolve relative download savePaths against the download directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ A Model Context Protocol (MCP) server that provides access to the Fastmail API, 
    # Only api.fastmail.com and www.fastmailusercontent.com are accepted by default.
    # For self-hosted JMAP servers, also set FASTMAIL_ALLOW_UNSAFE_BASE_URL=true.
    export FASTMAIL_BASE_URL="https://api.fastmail.com"
-   # Optional: customize attachment download directory (defaults to ~/Downloads/fastmail-mcp/)
+   # Optional: customize attachment download directory (defaults to ~/Downloads/fastmail-mcp/).
+   # download_attachment savePaths are confined to this directory; set it to the root
+   # you want attachments saved under to write there directly in one step.
    export FASTMAIL_DOWNLOAD_DIR="/path/to/your/downloads"
    ```
 
@@ -179,6 +181,7 @@ You can install this server as a Desktop Extension for Claude Desktop using the 
   - Parameters: `emailId` (required)
 - **download_attachment**: Download an email attachment. If savePath is provided, saves the file to disk and returns the file path and size. Otherwise returns a download URL.
   - Parameters: `emailId` (required), `attachmentId` (required), `savePath` (optional)
+  - `savePath` may be absolute or relative. Relative paths (including a bare filename) resolve against the download directory, so an attachment lands there in one step. Absolute paths must fall within that directory; traversal or symlink escape outside it is rejected. To save directly into your own location, set `FASTMAIL_DOWNLOAD_DIR` to that root — confinement stays on, scoped to the directory you choose.
 - **advanced_search**: Advanced email search with multiple criteria
   - Parameters: `query` (optional), `from` (optional), `to` (optional), `subject` (optional), `hasAttachment` (optional), `isUnread` (optional), `mailboxId` (optional), `after` (optional), `before` (optional), `limit` (default: 50), `ascending` (optional, oldest first)
 - **get_thread**: Get all emails in a conversation thread

--- a/src/index.ts
+++ b/src/index.ts
@@ -742,7 +742,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             savePath: {
               type: 'string',
-              description: `File path to save the attachment to. Paths are restricted to ${getDownloadDir() || '~/Downloads/fastmail-mcp/'} (configurable via FASTMAIL_DOWNLOAD_DIR). Path traversal outside this directory is rejected for security. Parent directories will be created automatically.`,
+              description: `File path to save the attachment to. May be absolute or relative; relative paths resolve against ${getDownloadDir() || '~/Downloads/fastmail-mcp/'} (configurable via FASTMAIL_DOWNLOAD_DIR), so a bare filename lands there in one step. Absolute paths must fall within that directory; traversal or symlink escape outside it is rejected for security. To save directly into your own location, set FASTMAIL_DOWNLOAD_DIR to that root. Parent directories will be created automatically.`,
             },
           },
           required: ['emailId', 'attachmentId'],
@@ -1539,7 +1539,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
               content: [
                 {
                   type: 'text',
-                  text: `Saved to: ${savePath} (${result.bytesWritten} bytes)`,
+                  text: `Saved to: ${result.savedPath} (${result.bytesWritten} bytes)`,
                 },
               ],
             };

--- a/src/jmap-client.test.ts
+++ b/src/jmap-client.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach, mock } from 'node:test';
 import assert from 'node:assert/strict';
 import { homedir } from 'os';
-import { resolve, join, basename } from 'path';
+import { resolve, join, basename, sep } from 'path';
 import { JmapClient } from './jmap-client.js';
 import { FastmailAuth } from './auth.js';
 
@@ -660,6 +660,41 @@ describe('validateSavePath', () => {
     const customDir = '/tmp/my-downloads';
     assert.throws(
       () => JmapClient.validateSavePath(`${customDir}/../../etc/shadow`, customDir),
+      (err: Error) => {
+        assert.match(err.message, /must be within/);
+        return true;
+      },
+    );
+  });
+
+  it('resolves a relative savePath against the download directory', () => {
+    const customDir = resolve('tmp', 'my-downloads');
+    const result = JmapClient.validateSavePath('report.pdf', customDir);
+    assert.equal(result, join(customDir, 'report.pdf'));
+  });
+
+  it('resolves a relative savePath with subdirectories against the download directory', () => {
+    const customDir = resolve('tmp', 'my-downloads');
+    const result = JmapClient.validateSavePath(join('thread', 'invoice.pdf'), customDir);
+    assert.equal(result, join(customDir, 'thread', 'invoice.pdf'));
+  });
+
+  it('rejects a relative savePath that traverses out of the download directory', () => {
+    const customDir = resolve('tmp', 'my-downloads');
+    assert.throws(
+      () => JmapClient.validateSavePath('../escape.pdf', customDir),
+      (err: Error) => {
+        assert.match(err.message, /must be within/);
+        return true;
+      },
+    );
+  });
+
+  it('rejects a Windows drive-absolute path outside the download directory', function () {
+    if (sep !== '\\') return; // drive-absolute semantics are win32-only
+    const customDir = resolve('C:\\Users\\me\\Downloads', 'fastmail-mcp');
+    assert.throws(
+      () => JmapClient.validateSavePath('C:\\Windows\\evil.exe', customDir),
       (err: Error) => {
         assert.match(err.message, /must be within/);
         return true;

--- a/src/jmap-client.ts
+++ b/src/jmap-client.ts
@@ -1082,7 +1082,13 @@ export class JmapClient {
 
   static validateSavePath(savePath: string, downloadDir?: string): string {
     const allowedDir = downloadDir ? resolve(normalize(downloadDir)) : JmapClient.DEFAULT_DOWNLOADS_DIR;
-    const resolved = resolve(normalize(savePath));
+    // Resolve relative paths against the allowed download directory rather than
+    // the process cwd (which is unpredictable for an MCP server launched by a
+    // client). Absolute paths are taken as-is; either way the containment check
+    // below is the security boundary. So a bare filename lands safely in the
+    // configured dir in one step, and an absolute path inside that dir writes
+    // exactly there.
+    const resolved = resolve(allowedDir, normalize(savePath));
 
     if (resolved.includes('\0')) {
       throw new Error('Save path contains null bytes');
@@ -1158,7 +1164,7 @@ export class JmapClient {
     return safePath;
   }
 
-  async downloadAttachmentToFile(emailId: string, attachmentId: string, savePath: string, downloadDir?: string): Promise<{ url: string; bytesWritten: number }> {
+  async downloadAttachmentToFile(emailId: string, attachmentId: string, savePath: string, downloadDir?: string): Promise<{ url: string; bytesWritten: number; savedPath: string }> {
     const safePath = await JmapClient.safeWritePath(savePath, downloadDir);
     const url = await this.downloadAttachment(emailId, attachmentId);
 
@@ -1175,7 +1181,7 @@ export class JmapClient {
     await mkdir(dirname(safePath), { recursive: true });
     await writeFile(safePath, buffer);
 
-    return { url, bytesWritten: buffer.length };
+    return { url, bytesWritten: buffer.length, savedPath: safePath };
   }
 
   async advancedSearch(filters: {


### PR DESCRIPTION
## Summary

`download_attachment` confines `savePath` to `FASTMAIL_DOWNLOAD_DIR` (default `~/Downloads/fastmail-mcp/`). Relative paths previously resolved against the **process cwd**, which is unpredictable for an MCP server launched by a client, so a bare filename like `report.pdf` almost always resolved outside the allowed dir and got rejected. In practice callers had to pass an absolute path inside the dir, or download-then-`mv`.

This resolves relative paths against the **allowed download directory** instead. A bare filename (or `thread/invoice.pdf`) now lands in the configured dir in one step.

## Why it's safe

The change is one line in `validateSavePath`:

```diff
-    const resolved = resolve(normalize(savePath));
+    const resolved = resolve(allowedDir, normalize(savePath));
```

- **Absolute paths are unchanged** — `resolve(base, absolutePath)` returns the absolute path, so `/etc/passwd`, `C:\Windows\...`, UNC, etc. ignore the base exactly as before and are still rejected by the containment check.
- **The containment check is the security boundary and is untouched** — it runs on the fully-resolved absolute path. A relative `../escape.pdf` still resolves out and is rejected.
- Net effect: relative inputs are redirected to a *more confined* default (inside the allowed dir) rather than the arbitrary cwd. No escape is opened.

## Also included

The success message echoed the raw `savePath`, which is misleading now that a relative input lands somewhere else. `downloadAttachmentToFile` now returns the resolved `savedPath` and the handler reports that.

Docs (tool description + README) updated to explain that relative paths resolve in the download dir, absolute paths must fall within it, and you widen scope by setting `FASTMAIL_DOWNLOAD_DIR` (confinement stays on, scoped to the directory you choose).

## Tests

Added to the `validateSavePath` suite: relative path resolves within the dir; relative subdir path; relative `../` traversal rejected; Windows drive-absolute escape rejected.

Note: the two pre-existing `safeWritePath (symlink escapes)` tests fail on Windows with `EPERM` because symlink creation needs elevation there — that's environmental and unrelated to this change (the touched code is `validateSavePath`/`downloadAttachmentToFile`). They pass on Linux/CI.
