### PR TITLE
Add draft filtering to get_thread and search_emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ You can install this server as a Desktop Extension for Claude Desktop using the 
 - **create_draft**: Create a minimal email draft (at least one of to/subject/body required)
   - Parameters: `to` (optional array), `cc` (optional array), `bcc` (optional array), `from` (optional), `mailboxId` (optional), `subject` (optional), `textBody` (optional), `htmlBody` (optional), `replyTo` (optional array)
 - **search_emails**: Search emails by content
-  - Parameters: `query` (required), `limit` (default: 20), `ascending` (optional, oldest first)
+  - Parameters: `query` (required), `limit` (default: 20), `ascending` (optional, oldest first), `excludeDrafts` (optional, omit draft messages)
+  - Drafts are **included by default**. Set `excludeDrafts: true` to filter them out server-side.
 - **get_recent_emails**: Get the most recent emails from a mailbox (inspired by JMAP-Samples top-ten)
   - Parameters: `limit` (default: 10, max: 50), `mailboxName` (default: 'inbox'), `ascending` (optional, oldest first)
 - **mark_email_read**: Mark an email as read or unread
@@ -182,7 +183,8 @@ You can install this server as a Desktop Extension for Claude Desktop using the 
 - **advanced_search**: Advanced email search with multiple criteria
   - Parameters: `query` (optional), `from` (optional), `to` (optional), `subject` (optional), `hasAttachment` (optional), `isUnread` (optional), `mailboxId` (optional), `after` (optional), `before` (optional), `limit` (default: 50), `ascending` (optional, oldest first)
 - **get_thread**: Get all emails in a conversation thread
-  - Parameters: `threadId` (required)
+  - Parameters: `threadId` (required), `includeDrafts` (optional, include in-progress drafts)
+  - Draft messages are **excluded by default** (an in-progress reply is noise when reading a conversation). Set `includeDrafts: true` to include them. Drafts are identified by the `$draft` keyword, so the asymmetry with `search_emails` (which includes drafts by default) is deliberate: a search should still find everything you've written.
 
 ### Email Statistics & Analytics
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -412,7 +412,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: 'search_emails',
-        description: 'Search emails by subject or content',
+        description: 'Search emails by subject or content. Drafts are included by default; set excludeDrafts=true to omit draft messages from results.',
         inputSchema: {
           type: 'object',
           properties: {
@@ -428,6 +428,10 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             ascending: {
               type: 'boolean',
               description: 'Sort oldest first instead of newest first (default: false)',
+            },
+            excludeDrafts: {
+              type: 'boolean',
+              description: 'Omit draft messages from results (default: false, drafts included). Filtered server-side via the $draft keyword.',
             },
           },
           required: ['query'],
@@ -808,13 +812,17 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: 'get_thread',
-        description: 'Get all emails in a conversation thread',
+        description: 'Get all emails in a conversation thread. Draft messages are excluded by default; set includeDrafts=true to include in-progress drafts in the thread.',
         inputSchema: {
           type: 'object',
           properties: {
             threadId: {
               type: 'string',
               description: 'ID of the thread/conversation',
+            },
+            includeDrafts: {
+              type: 'boolean',
+              description: 'Include draft messages in the thread (default: false, drafts excluded).',
             },
           },
           required: ['threadId'],
@@ -1235,12 +1243,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'search_emails': {
-        const { query, limit, ascending } = args as any;
+        const { query, limit, ascending, excludeDrafts } = args as any;
         if (!query) {
           throw new McpError(ErrorCode.InvalidParams, 'query is required');
         }
         const validLimit = Math.min(Math.max(Number(limit) || 20, 1), 100);
-        const emails = await client.searchEmails(query, validLimit, !!ascending);
+        const emails = await client.searchEmails(query, validLimit, !!ascending, coerceBool(excludeDrafts) ?? false);
         return {
           content: [
             {
@@ -1585,13 +1593,13 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'get_thread': {
-        const { threadId } = args as any;
+        const { threadId, includeDrafts } = args as any;
         if (!threadId) {
           throw new McpError(ErrorCode.InvalidParams, 'threadId is required');
         }
         const client = initializeClient();
         try {
-          const thread = await client.getThread(threadId);
+          const thread = await client.getThread(threadId, coerceBool(includeDrafts) ?? false);
           return {
             content: [
               {

--- a/src/jmap-client-extra.test.ts
+++ b/src/jmap-client-extra.test.ts
@@ -626,3 +626,49 @@ describe('ascending sort parameter', () => {
     });
   });
 });
+
+describe('getThread draft handling', () => {
+  let client: JmapClient;
+
+  beforeEach(() => {
+    client = makeClient();
+  });
+
+  // A thread containing a normal email plus an in-progress draft reply.
+  const stubThreadWithDraft = () => {
+    let callCount = 0;
+    return mock.method(client, 'makeRequest', async () => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          methodResponses: [
+            ['Email/get', { list: [{ threadId: 'thread-1' }] }, 'checkEmail'],
+          ],
+        };
+      }
+      return {
+        methodResponses: [
+          ['Thread/get', { list: [{ id: 'thread-1', emailIds: ['e1', 'e2'] }] }, 'getThread'],
+          ['Email/get', { list: [
+            { id: 'e1', subject: 'Sent message', keywords: { $seen: true } },
+            { id: 'e2', subject: 'Draft reply', keywords: { $draft: true } },
+          ] }, 'emails'],
+        ],
+      };
+    });
+  };
+
+  it('excludes draft messages by default', async () => {
+    stubThreadWithDraft();
+    const thread = await client.getThread('e1');
+    assert.equal(thread.length, 1);
+    assert.equal(thread[0].id, 'e1');
+  });
+
+  it('includes drafts when includeDrafts is true', async () => {
+    stubThreadWithDraft();
+    const thread = await client.getThread('e1', true);
+    assert.equal(thread.length, 2);
+    assert.deepEqual(thread.map((e: any) => e.id), ['e1', 'e2']);
+  });
+});

--- a/src/jmap-client.test.ts
+++ b/src/jmap-client.test.ts
@@ -579,6 +579,32 @@ describe('searchEmails', () => {
       },
     );
   });
+
+  it('excludeDrafts adds notKeyword $draft to the server-side filter', async () => {
+    const makeReq = mock.method(client, 'makeRequest', async () => ({
+      methodResponses: [
+        ['Email/query', { ids: [] }, 'query'],
+        ['Email/get', { list: [] }, 'emails'],
+      ],
+    }));
+    await client.searchEmails('quarterly', 10, false, true);
+    const filter = makeReq.mock.calls[0].arguments[0].methodCalls[0][1].filter;
+    assert.equal(filter.text, 'quarterly');
+    assert.equal(filter.notKeyword, '$draft');
+  });
+
+  it('includes drafts by default (no notKeyword in the filter)', async () => {
+    const makeReq = mock.method(client, 'makeRequest', async () => ({
+      methodResponses: [
+        ['Email/query', { ids: [] }, 'query'],
+        ['Email/get', { list: [] }, 'emails'],
+      ],
+    }));
+    await client.searchEmails('quarterly', 10);
+    const filter = makeReq.mock.calls[0].arguments[0].methodCalls[0][1].filter;
+    assert.equal(filter.text, 'quarterly');
+    assert.equal(filter.notKeyword, undefined);
+  });
 });
 
 // ---------- validateSavePath tests ----------

--- a/src/jmap-client.ts
+++ b/src/jmap-client.ts
@@ -1243,15 +1243,20 @@ export class JmapClient {
     return this.getListResult(response, 1);
   }
 
-  async searchEmails(query: string, limit: number = 20, ascending: boolean = false): Promise<any[]> {
+  async searchEmails(query: string, limit: number = 20, ascending: boolean = false, excludeDrafts: boolean = false): Promise<any[]> {
     const session = await this.getSession();
+
+    // A JMAP FilterCondition ANDs its properties, so text + notKeyword means
+    // "matches the query AND is not a draft". Applied server-side in Email/query.
+    const filter: any = { text: query };
+    if (excludeDrafts) filter.notKeyword = '$draft';
 
     const request: JmapRequest = {
       using: ['urn:ietf:params:jmap:core', 'urn:ietf:params:jmap:mail'],
       methodCalls: [
         ['Email/query', {
           accountId: session.accountId,
-          filter: { text: query },
+          filter,
           sort: [{ property: 'receivedAt', isAscending: ascending }],
           limit
         }, 'query'],
@@ -1267,7 +1272,7 @@ export class JmapClient {
     return this.getListResult(response, 1);
   }
 
-  async getThread(threadId: string): Promise<any[]> {
+  async getThread(threadId: string, includeDrafts: boolean = false): Promise<any[]> {
     const session = await this.getSession();
 
     // First, check if threadId is actually an email ID and resolve the thread
@@ -1320,7 +1325,11 @@ export class JmapClient {
       throw new Error(`Thread with ID '${actualThreadId}' not found`);
     }
 
-    return this.getListResult(response, 1);
+    // Drafts (e.g. an in-progress reply) are noise when reading a conversation,
+    // so exclude them by default. Identify by the $draft keyword (survives a
+    // draft moved out of the Drafts mailbox); opt back in via includeDrafts.
+    const emails = this.getListResult(response, 1);
+    return includeDrafts ? emails : emails.filter((e: any) => !e.keywords?.$draft);
   }
 
   async getMailboxStats(mailboxId?: string): Promise<any> {


### PR DESCRIPTION
## What

Adds keyword-based draft filtering to two read tools, with deliberately asymmetric defaults:

- **`get_thread`** excludes drafts **by default** (an in-progress reply is noise when reading a conversation). Opt in with `includeDrafts: true`.
- **`search_emails`** includes drafts **by default** (a search should find everything you've written). Opt out with `excludeDrafts: true`.

## Why

A draft reply sitting in a thread shows up as a thread member, so `get_thread` reconstructs the conversation with a half-written message the user never sent. Searches similarly surface drafts mixed in with real mail. Today a caller has to filter these out client-side.

The asymmetry is intentional: when *reading a conversation* a draft is noise, but when *searching* you usually do want to find your own drafts, so each tool gets the default that matches how it's used. Both can be overridden.

## How

- Drafts are identified by the **`$draft` keyword**, not mailbox role — robust even when a draft has been moved out of the Drafts mailbox.
- `search_emails` filters **server-side**: `notKeyword: '$draft'` is added to the existing `Email/query` `text` condition (a JMAP FilterCondition ANDs its properties). No post-filtering.
- `get_thread` filters the returned email list **post-fetch**, since `Thread/get` returns all member ids and can't scope them server-side. `keywords` is already requested in that tool's `Email/get`, so no extra round-trip.
- Both new params are coerced with the existing `coerceBool`, so a string `"true"`/`"false"` from a client is handled correctly.

## Tests

New unit tests:
- `search_emails`: asserts `notKeyword: '$draft'` is present in the sent request when `excludeDrafts` is set, and absent by default.
- `get_thread`: a thread containing one sent message + one `$draft` reply returns only the sent message by default, and both when `includeDrafts: true`.

`npx tsc --noEmit` is clean and the new tests pass. (The two `safeWritePath` symlink tests fail locally on Windows with `EPERM` because creating symlinks needs elevation there; they are untouched by this PR and pass on Linux CI.)

No matching issue, so no `Closes`. Docs (tool descriptions + README) updated in the same commit.
