### PR TITLE
Fix unescapeICalText corrupting an escaped backslash before "n"

### DIFF
--- a/src/caldav-client.test.ts
+++ b/src/caldav-client.test.ts
@@ -6,6 +6,7 @@ import {
   formatICalDate,
   parseCalendarObject,
   escapeICalText,
+  unescapeICalText,
   validateAndFormatICalDate,
   CalDAVCalendarClient,
 } from './caldav-client.js';
@@ -267,6 +268,39 @@ describe('escapeICalText', () => {
     assert.ok(!escaped.includes('\r'), 'escaped text must not contain literal carriage returns');
     // The entire payload is on one logical ICS line, so END:VEVENT can't terminate the block
     assert.ok(escaped.startsWith('Meeting\\n'), 'newlines should be escaped, not literal');
+  });
+});
+
+describe('unescapeICalText', () => {
+  it('unescapes newlines', () => {
+    assert.equal(unescapeICalText('line1\\nline2'), 'line1\nline2');
+    assert.equal(unescapeICalText('line1\\Nline2'), 'line1\nline2');
+  });
+
+  it('unescapes semicolons and commas', () => {
+    assert.equal(unescapeICalText('a\\;b\\;c'), 'a;b;c');
+    assert.equal(unescapeICalText('Room A\\, Building 1'), 'Room A, Building 1');
+  });
+
+  it('unescapes backslashes', () => {
+    assert.equal(unescapeICalText('path\\\\to\\\\file'), 'path\\to\\file');
+  });
+
+  it('decodes an escaped backslash followed by "n" as a literal backslash + n, not a newline', () => {
+    // "\\n" in iCal = an escaped backslash ("\\") followed by a literal "n".
+    // A chained-replace implementation corrupts this into "\<newline>".
+    assert.equal(unescapeICalText('\\\\n'), '\\n');
+    assert.equal(unescapeICalText('C:\\\\next'), 'C:\\next');
+  });
+
+  it('round-trips with escapeICalText', () => {
+    for (const original of ['plain', 'a;b,c', 'line1\nline2', 'back\\slash', 'C:\\next', 'mix\n;,\\end']) {
+      assert.equal(unescapeICalText(escapeICalText(original)), original);
+    }
+  });
+
+  it('leaves plain text unchanged', () => {
+    assert.equal(unescapeICalText('Team Standup'), 'Team Standup');
   });
 });
 

--- a/src/caldav-client.ts
+++ b/src/caldav-client.ts
@@ -115,13 +115,20 @@ export function parseCalendarObject(obj: DAVCalendarObject): CalendarEvent {
 /**
  * Unescape an iCalendar text value (RFC 5545 §3.3.11).
  * Reverses escaping of newlines, semicolons, commas, and backslashes.
+ *
+ * Done in a single left-to-right pass so each escape is decoded exactly once.
+ * Chained .replace() calls re-scan the whole string and corrupt an escaped
+ * backslash that precedes an escapable char: e.g. "\\n" (an escaped backslash
+ * followed by a literal "n") would have its second "\n" turned into a newline,
+ * yielding "\<newline>" instead of the correct "\n".
  */
 export function unescapeICalText(value: string): string {
-  return value
-    .replace(/\\n/gi, '\n')
-    .replace(/\\;/g, ';')
-    .replace(/\\,/g, ',')
-    .replace(/\\\\/g, '\\');
+  return value.replace(/\\(\\|;|,|[nN])/g, (_, ch) => {
+    if (ch === 'n' || ch === 'N') return '\n';
+    if (ch === ',') return ',';
+    if (ch === ';') return ';';
+    return '\\';
+  });
 }
 
 /**


### PR DESCRIPTION
## The bug

`unescapeICalText` decodes an iCalendar text value (RFC 5545 §3.3.11) in four chained `.replace()` passes, newline first:

```js
return value
  .replace(/\n/gi, '\n')
  .replace(/\;/g, ';')
  .replace(/\,/g, ',')
  .replace(/\\/g, '\');
```

Because each pass re-scans the whole string, an **escaped backslash that sits in front of an escapable character gets corrupted**. The iCal sequence `\n` means "an escaped backslash (`\`) followed by a literal `n`" and should decode to `\n` (backslash + n). But the first pass matches the *trailing* `\n` and turns it into a newline, leaving `\` + newline:

```
unescapeICalText('\\n')  // input represents iCal  \n
// expected: '\n'  (backslash, n)
// actual:   '\<newline>'
```

The same corruption applies to `\;` and `\,` preceded by an escaped backslash. In practice this mangles any text whose content has a backslash immediately before `n`/`N`/`;`/`,` — e.g. a Windows path like `C:\next` in an event description or location comes back as `C:` + newline + `ext`.

## The fix

Decode in a single left-to-right pass, so each backslash escape is consumed exactly once and an escaped backslash can't recombine with the following character:

```js
return value.replace(/\(\|;|,|[nN])/g, (_, ch) => {
  if (ch === 'n' || ch === 'N') return '\n';
  if (ch === ',') return ',';
  if (ch === ';') return ';';
  return '\';
});
```

Behavior is identical for every input that doesn't contain an escaped backslash before an escapable char, so this is a strict correctness fix with no change to the common cases.

## Tests

Adds a `describe('unescapeICalText')` block (there was none) covering newlines (`\n` and `\N`), semicolons, commas, backslashes, the escaped-backslash-before-`n` regression, a `C:\next`-style path, and a round-trip against `escapeICalText`.

`npx tsc --noEmit` is clean and the new tests pass. (The two `safeWritePath` symlink tests fail locally on Windows with `EPERM` because creating symlinks needs elevation; they are untouched by this PR and pass on Linux CI.)

No matching issue, so no `Closes`.
