### PR TITLE
Fix: edit_draft no longer corrupts the other body on a partial edit

### DIFF
--- a/src/jmap-client.test.ts
+++ b/src/jmap-client.test.ts
@@ -373,6 +373,76 @@ describe('updateDraft', () => {
       },
     );
   });
+
+  // Body-extraction correctness (the `|| true` bug). Fixtures mirror real server shapes:
+  // a single-format draft aliases its one part into BOTH the textBody and htmlBody lists;
+  // a dual-format draft has two distinct typed parts. Assertions are on the recreate
+  // OUTPUT, whose bodyValues are re-keyed to 'text'/'html'.
+
+  it('preserves a single text-only body without synthesising a phantom html part', async () => {
+    const aliasedDraft = {
+      ...EXISTING_DRAFT,
+      textBody: [{ partId: '1', type: 'text/plain' }],
+      htmlBody: [{ partId: '1', type: 'text/plain' }], // server aliases the one part into both lists
+      bodyValues: { '1': { value: 'Plain only' } },
+    };
+    const makeReq = mock.method(client, 'makeRequest', async (req: any) => {
+      if (req.methodCalls[0][0] === 'Email/get') {
+        return { methodResponses: [['Email/get', { list: [aliasedDraft] }, 'getEmail']] };
+      }
+      return { methodResponses: [['Email/set', { created: { draft: { id: 'draft-2' } }, destroyed: ['draft-1'] }, 'updateDraft']] };
+    });
+
+    await client.updateDraft('draft-1', { subject: 'New subject' });
+
+    const emailObj = makeReq.mock.calls[1].arguments[0].methodCalls[0][1].create.draft;
+    assert.equal(emailObj.htmlBody, undefined);
+    assert.deepEqual(emailObj.bodyValues, { text: { value: 'Plain only' } });
+  });
+
+  it('preserves both bodies from their own parts on a subject-only edit', async () => {
+    const dualDraft = {
+      ...EXISTING_DRAFT,
+      textBody: [{ partId: '1', type: 'text/plain' }],
+      htmlBody: [{ partId: '2', type: 'text/html' }],
+      bodyValues: { '1': { value: 'The text' }, '2': { value: '<p>The html</p>' } },
+    };
+    const makeReq = mock.method(client, 'makeRequest', async (req: any) => {
+      if (req.methodCalls[0][0] === 'Email/get') {
+        return { methodResponses: [['Email/get', { list: [dualDraft] }, 'getEmail']] };
+      }
+      return { methodResponses: [['Email/set', { created: { draft: { id: 'draft-2' } }, destroyed: ['draft-1'] }, 'updateDraft']] };
+    });
+
+    await client.updateDraft('draft-1', { subject: 'New subject' });
+
+    const emailObj = makeReq.mock.calls[1].arguments[0].methodCalls[0][1].create.draft;
+    assert.deepEqual(emailObj.bodyValues, {
+      text: { value: 'The text' },
+      html: { value: '<p>The html</p>' },
+    });
+  });
+
+  it('updates only textBody and preserves the existing htmlBody', async () => {
+    const dualDraft = {
+      ...EXISTING_DRAFT,
+      textBody: [{ partId: '1', type: 'text/plain' }],
+      htmlBody: [{ partId: '2', type: 'text/html' }],
+      bodyValues: { '1': { value: 'The text' }, '2': { value: '<p>The html</p>' } },
+    };
+    const makeReq = mock.method(client, 'makeRequest', async (req: any) => {
+      if (req.methodCalls[0][0] === 'Email/get') {
+        return { methodResponses: [['Email/get', { list: [dualDraft] }, 'getEmail']] };
+      }
+      return { methodResponses: [['Email/set', { created: { draft: { id: 'draft-2' } }, destroyed: ['draft-1'] }, 'updateDraft']] };
+    });
+
+    await client.updateDraft('draft-1', { textBody: 'NEW text' });
+
+    const emailObj = makeReq.mock.calls[1].arguments[0].methodCalls[0][1].create.draft;
+    assert.equal(emailObj.bodyValues.text.value, 'NEW text');
+    assert.equal(emailObj.bodyValues.html.value, '<p>The html</p>');
+  });
 });
 
 // ---------- sendDraft ----------

--- a/src/jmap-client.ts
+++ b/src/jmap-client.ts
@@ -542,17 +542,26 @@ export class JmapClient {
       }
     }
 
-    // Extract existing body values
-    const existingTextBody = existingEmail.bodyValues
-      ? Object.values(existingEmail.bodyValues).find((bv: any) =>
-          existingEmail.textBody?.some((tb: any) => tb.partId === (bv as any).partId || true)
-        )
-      : null;
-    const existingHtmlBody = existingEmail.bodyValues
-      ? Object.values(existingEmail.bodyValues).find((bv: any) =>
-          existingEmail.htmlBody?.some((hb: any) => hb.partId === (bv as any).partId || true)
-        )
-      : null;
+    // Extract existing body values by MIME type, keyed into bodyValues by partId.
+    //
+    // The previous lookup used `tb.partId === bv.partId || true` — always true, since the
+    // bodyValue objects from Object.values() have no partId field (partId is the map key).
+    // So both bodies collapsed to Object.values(bodyValues)[0], and a subject-only or
+    // single-body edit would overwrite or lose the other format (and clients render the
+    // HTML alternative, RFC 2046 5.1.4, so recipients saw the wrong content).
+    //
+    // Note also: when a draft has only one body, the server aliases that one part into
+    // BOTH the textBody and htmlBody lists (e.g. a text-only draft lists the text/plain
+    // part under htmlBody too, with type "text/plain"). So we must select by the part's
+    // actual MIME type — not mere presence in a list — or we'd read the text value into
+    // the html slot and synthesise a phantom text/html part on recreate.
+    const bodyValues = existingEmail.bodyValues || {};
+    const bodyValueForType = (parts: any[] | undefined, mimeType: string): string | undefined => {
+      const part = parts?.find((p: any) => p.type === mimeType && p.partId != null && bodyValues[p.partId]);
+      return part ? bodyValues[part.partId].value : undefined;
+    };
+    const existingTextValue = bodyValueForType(existingEmail.textBody, 'text/plain');
+    const existingHtmlValue = bodyValueForType(existingEmail.htmlBody, 'text/html');
 
     // Merge: updates override existing values
     const mergedSubject = updates.subject !== undefined ? updates.subject : (existingEmail.subject || '');
@@ -561,8 +570,8 @@ export class JmapClient {
     const mergedBcc = updates.bcc !== undefined ? updates.bcc.map(addr => ({ email: addr })) : (existingEmail.bcc || []);
     const mergedReplyTo = updates.replyTo !== undefined ? updates.replyTo.map(addr => ({ email: addr })) : (existingEmail.replyTo || null);
 
-    const textBodyValue = updates.textBody !== undefined ? updates.textBody : (existingTextBody as any)?.value;
-    const htmlBodyValue = updates.htmlBody !== undefined ? updates.htmlBody : (existingHtmlBody as any)?.value;
+    const textBodyValue = updates.textBody !== undefined ? updates.textBody : existingTextValue;
+    const htmlBodyValue = updates.htmlBody !== undefined ? updates.htmlBody : existingHtmlValue;
 
     const emailObject: any = {
       mailboxIds: existingEmail.mailboxIds,


### PR DESCRIPTION
## The bug

`updateDraft` rebuilds a draft's body to re-send it (JMAP bodies are immutable, so an edit is a destroy + recreate). It reads the existing bodies back from the fetched email:

```js
const existingTextBody = ...Object.values(bodyValues).find((bv) =>
  existingEmail.textBody?.some((tb) => tb.partId === bv.partId || true));
```

The `|| true` makes the predicate unconditionally true — and the bodyValue objects from `Object.values()` have no `partId` field anyway (partId is the map *key*). So both `existingTextBody` and `existingHtmlBody` resolve to `Object.values(bodyValues)[0]`, the first part.

Consequences on an edit that doesn't explicitly set a given body:

- **Dual-format draft, edit only the subject (or only one body):** the other body is overwritten with the first part's value. e.g. a subject-only edit replaces the HTML body with the plain-text value; since clients render the HTML alternative (RFC 2046 §5.1.4), the recipient sees the wrong content.
- **Single-format draft:** the server aliases the one part into *both* the `textBody` and `htmlBody` lists (a text-only draft's `htmlBody` entry has `type: "text/plain"`), so the lookup pulls that value into the missing format and a phantom part is synthesised on recreate.

## The fix

Select each existing body value by MIME type, keyed into `bodyValues` by the matched part's `partId`:

```js
const bodyValues = existingEmail.bodyValues || {};
const bodyValueForType = (parts, mimeType) => {
  const part = parts?.find((p) => p.type === mimeType && p.partId != null && bodyValues[p.partId]);
  return part ? bodyValues[part.partId].value : undefined;
};
const existingTextValue = bodyValueForType(existingEmail.textBody, 'text/plain');
const existingHtmlValue = bodyValueForType(existingEmail.htmlBody, 'text/html');
```

Matching by MIME type (rather than only keying by partId) is what handles the single-format aliasing: a text-only draft's `htmlBody` entry is `text/plain`, so it correctly yields no HTML value and no phantom part. `type` is already requested in the `Email/get` `bodyProperties`, so there is no request change.

Verified against a live Fastmail account (text-only, html-only, and dual-part drafts):

- subject-only edit on a dual draft → both bodies preserved
- textBody-only edit → text updated, HTML partner preserved
- text-only draft edit → no phantom html part

## Tests

Adds 3 unit tests to the `updateDraft` suite covering the aliased single-format and dual-format shapes, asserting on the recreate output. Each fails before the fix and passes after.

(The 2 pre-existing `safeWritePath` symlink tests fail locally on Windows — EPERM, symlink creation needs elevation — but are untouched by this change and pass on CI.)
