### PR TITLE
Fix: coerce all recipient fields so stringified to/cc/bcc/replyTo don't crash

### DIFF
--- a/src/coerce.test.ts
+++ b/src/coerce.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { coerceStringArray, coerceBool, redactBearerTokens } from './coerce.js';
+import { coerceStringArray, coerceRecipients, coerceBool, redactBearerTokens } from './coerce.js';
 
 describe('coerceStringArray', () => {
   it('returns undefined for undefined input', () => {
@@ -51,6 +51,50 @@ describe('coerceStringArray', () => {
 
   it('falls back to comma-split when JSON parsing fails', () => {
     assert.deepEqual(coerceStringArray('[not valid json]'), ['[not valid json]']);
+  });
+});
+
+describe('coerceRecipients', () => {
+  it('coerces all four fields from arrays, JSON-strings, comma-strings, and bare strings', () => {
+    const result = coerceRecipients({
+      to: ['a@b.com'],
+      cc: '["c@d.com", "e@f.com"]',
+      bcc: 'g@h.com, i@j.com',
+      replyTo: 'k@l.com',
+    });
+    assert.deepEqual(result, {
+      to: ['a@b.com'],
+      cc: ['c@d.com', 'e@f.com'],
+      bcc: ['g@h.com', 'i@j.com'],
+      replyTo: ['k@l.com'],
+    });
+  });
+
+  it('coerces empty string to empty array for each field', () => {
+    assert.deepEqual(coerceRecipients({ to: '', cc: '', bcc: '', replyTo: '' }), {
+      to: [],
+      cc: [],
+      bcc: [],
+      replyTo: [],
+    });
+  });
+
+  it('returns undefined for omitted fields', () => {
+    assert.deepEqual(coerceRecipients({}), {
+      to: undefined,
+      cc: undefined,
+      bcc: undefined,
+      replyTo: undefined,
+    });
+  });
+
+  it('returns undefined for non-string, non-array values', () => {
+    assert.deepEqual(coerceRecipients({ to: 123, cc: {}, bcc: true, replyTo: null } as any), {
+      to: undefined,
+      cc: undefined,
+      bcc: undefined,
+      replyTo: undefined,
+    });
   });
 });
 

--- a/src/coerce.ts
+++ b/src/coerce.ts
@@ -30,6 +30,21 @@ export function coerceStringArray(value: unknown): string[] | undefined {
   return trimmed.split(',').map(s => s.trim()).filter(Boolean);
 }
 
+// Coerce the four recipient list fields from whatever shape a (possibly lenient)
+// client sent into string[] | undefined, so the JMAP client's .map(parseAddress)
+// calls never receive a bare string (issue #54). Pass the raw tool args; reads
+// only to/cc/bcc/replyTo and returns the coerced quartet.
+export function coerceRecipients(args: { to?: unknown; cc?: unknown; bcc?: unknown; replyTo?: unknown }): {
+  to?: string[]; cc?: string[]; bcc?: string[]; replyTo?: string[];
+} {
+  return {
+    to: coerceStringArray(args.to),
+    cc: coerceStringArray(args.cc),
+    bcc: coerceStringArray(args.bcc),
+    replyTo: coerceStringArray(args.replyTo),
+  };
+}
+
 export function coerceBool(value: unknown): boolean | undefined {
   if (typeof value === 'boolean') return value;
   if (value === 'true') return true;

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import { FastmailAuth, FastmailConfig } from './auth.js';
 import { JmapClient } from './jmap-client.js';
 import { ContactsCalendarClient } from './contacts-calendar.js';
 import { CalDAVCalendarClient } from './caldav-client.js';
-import { coerceStringArray, coerceBool, redactBearerTokens } from './coerce.js';
+import { coerceRecipients, coerceBool, redactBearerTokens } from './coerce.js';
 
 const server = new Server(
   {
@@ -1037,8 +1037,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'send_email': {
-        const { to, cc, bcc, from, mailboxId, subject, textBody, htmlBody, inReplyTo, references, replyTo } = args as any;
-        const toArray = coerceStringArray(to);
+        const { from, mailboxId, subject, textBody, htmlBody, inReplyTo, references } = args as any;
+        const { to: toArray, cc, bcc, replyTo } = coerceRecipients(args as any);
         if (!toArray || toArray.length === 0) {
           throw new McpError(ErrorCode.InvalidParams, 'to field is required and must be a non-empty array');
         }
@@ -1074,7 +1074,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'reply_email': {
-        const { originalEmailId, to, cc, bcc, from, textBody, htmlBody, send, replyTo } = args as any;
+        const { originalEmailId, from, textBody, htmlBody, send } = args as any;
+        const { to: toArray, cc, bcc, replyTo } = coerceRecipients(args as any);
         const shouldSend = coerceBool(send) ?? true;
         if (!originalEmailId) {
           throw new McpError(ErrorCode.InvalidParams, 'originalEmailId is required');
@@ -1105,7 +1106,6 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         }
 
         // Default recipients to the original sender
-        const toArray = coerceStringArray(to);
         const replyRecipients = (toArray && toArray.length > 0)
           ? toArray
           : (Array.isArray(originalEmail.from) ? originalEmail.from.map((addr: any) => addr.email).filter(Boolean) : []);
@@ -1152,7 +1152,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'create_draft': {
-        const { to, cc, bcc, from, mailboxId, subject, textBody, htmlBody, inReplyTo, references, replyTo } = args as any;
+        const { from, mailboxId, subject, textBody, htmlBody, inReplyTo, references } = args as any;
+        const { to, cc, bcc, replyTo } = coerceRecipients(args as any);
 
         if (!to?.length && !subject && !textBody && !htmlBody) {
           throw new McpError(ErrorCode.InvalidParams, 'At least one of to, subject, textBody, or htmlBody must be provided');
@@ -1190,7 +1191,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'edit_draft': {
-        const { emailId, to, cc, bcc, from, subject, textBody, htmlBody, replyTo } = args as any;
+        const { emailId, from, subject, textBody, htmlBody } = args as any;
+        const { to, cc, bcc, replyTo } = coerceRecipients(args as any);
         if (!emailId) {
           throw new McpError(ErrorCode.InvalidParams, 'emailId is required');
         }


### PR DESCRIPTION
## Problem

Lenient MCP clients (issue #54 — clients that stringify structured params before dispatch) send the recipient array fields as strings. `to`/`cc`/`bcc`/`replyTo` are declared as arrays, but the handlers coerce them unevenly:

- `send_email` / `reply_email` coerce only `to` (via `coerceStringArray`)
- `create_draft` / `edit_draft` coerce nothing

So when any *other* recipient field arrives as a string, the JMAP client calls `.map(parseAddress)` on it and throws `TypeError: <field>.map is not a function`:

| Tool | Crashes on |
|---|---|
| `send_email` / `reply_email` | `cc`/`bcc`/`replyTo` as any string |
| `create_draft` | a non-empty string `to`/`cc`/`bcc`/`replyTo` |
| `edit_draft` | any string `to`/`cc`/`bcc`/`replyTo` (including `""`) |

The crash surfaces to the model as an opaque internal error rather than something it can recover from.

## Fix

Add a `coerceRecipients(args)` helper in `coerce.ts` that fans the existing `coerceStringArray` over `to`/`cc`/`bcc`/`replyTo`, and wire it into all four send/draft handlers so the JMAP client always receives `string[] | undefined`.

- Strict no-op for compliant clients sending proper arrays.
- `from` is a single identity string (not a list), so it's untouched.

## Testing

- `npx tsc --noEmit` clean.
- New `coerceRecipients` unit tests in `coerce.test.ts`: array / JSON-string / comma-string / bare-string coercion, `"" → []`, omitted → `undefined`, non-string → `undefined`.
- Full suite green, except 2 pre-existing Windows-only `safeWritePath` symlink-EPERM failures that are environmental and unrelated to this change.

Refs #54.
