### PR TITLE
Integrate PR #49: surface total result count in query-based tool responses

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "dxt_version": "0.1",
   "name": "fastmail-mcp",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "description": "MCP server for Fastmail API integration",
   "author": {
     "name": "Jeremy Gill"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fastmail-mcp",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fastmail-mcp",
-      "version": "1.11.1",
+      "version": "1.12.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastmail-mcp",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "description": "MCP server for Fastmail API integration",
   "main": "dist/index.js",
   "type": "module",

--- a/src/contacts-calendar.ts
+++ b/src/contacts-calendar.ts
@@ -1,4 +1,4 @@
-import { JmapClient, JmapRequest } from './jmap-client.js';
+import { JmapClient, JmapRequest, QueryResult } from './jmap-client.js';
 
 export class ContactsCalendarClient extends JmapClient {
   
@@ -12,7 +12,7 @@ export class ContactsCalendarClient extends JmapClient {
     return !!session.capabilities['urn:ietf:params:jmap:calendars'];
   }
   
-  async getContacts(limit: number = 50): Promise<any[]> {
+  async getContacts(limit: number = 50): Promise<QueryResult> {
     // Check permissions first
     const hasPermission = await this.checkContactsPermission();
     if (!hasPermission) {
@@ -20,14 +20,15 @@ export class ContactsCalendarClient extends JmapClient {
     }
 
     const session = await this.getSession();
-    
+
     // Try CardDAV namespace first, then Fastmail specific
     const request: JmapRequest = {
       using: ['urn:ietf:params:jmap:core', 'urn:ietf:params:jmap:contacts'],
       methodCalls: [
         ['ContactCard/query', {
           accountId: session.accountId,
-          limit
+          limit,
+          calculateTotal: true
         }, 'query'],
         ['ContactCard/get', {
           accountId: session.accountId,
@@ -39,7 +40,7 @@ export class ContactsCalendarClient extends JmapClient {
 
     try {
       const response = await this.makeRequest(request);
-      return this.getListResult(response, 1);
+      return this.getQueryResult(response, 0, 1);
     } catch (error) {
       // Fallback: try to get contacts using AddressBook methods
       const fallbackRequest: JmapRequest = {
@@ -50,10 +51,11 @@ export class ContactsCalendarClient extends JmapClient {
           }, 'addressbooks']
         ]
       };
-      
+
       try {
         const fallbackResponse = await this.makeRequest(fallbackRequest);
-        return this.getListResult(fallbackResponse, 0);
+        const items = this.getListResult(fallbackResponse, 0);
+        return { items };
       } catch (fallbackError) {
         throw new Error(`Contacts not supported or accessible: ${error instanceof Error ? error.message : String(error)}. Try checking account permissions or enabling contacts API access in Fastmail settings.`);
       }
@@ -87,7 +89,7 @@ export class ContactsCalendarClient extends JmapClient {
     }
   }
 
-  async searchContacts(query: string, limit: number = 20): Promise<any[]> {
+  async searchContacts(query: string, limit: number = 20): Promise<QueryResult> {
     // Check permissions first
     const hasPermission = await this.checkContactsPermission();
     if (!hasPermission) {
@@ -95,14 +97,15 @@ export class ContactsCalendarClient extends JmapClient {
     }
 
     const session = await this.getSession();
-    
+
     const request: JmapRequest = {
       using: ['urn:ietf:params:jmap:core', 'urn:ietf:params:jmap:contacts'],
       methodCalls: [
         ['ContactCard/query', {
           accountId: session.accountId,
           filter: { text: query },
-          limit
+          limit,
+          calculateTotal: true
         }, 'query'],
         ['ContactCard/get', {
           accountId: session.accountId,
@@ -114,7 +117,7 @@ export class ContactsCalendarClient extends JmapClient {
 
     try {
       const response = await this.makeRequest(request);
-      return this.getListResult(response, 1);
+      return this.getQueryResult(response, 0, 1);
     } catch (error) {
       throw new Error(`Contact search not supported: ${error instanceof Error ? error.message : String(error)}. Try checking account permissions or enabling contacts API access in Fastmail settings.`);
     }
@@ -155,9 +158,9 @@ export class ContactsCalendarClient extends JmapClient {
     }
 
     const session = await this.getSession();
-    
+
     const filter = calendarId ? { inCalendar: calendarId } : {};
-    
+
     const request: JmapRequest = {
       using: ['urn:ietf:params:jmap:core', 'urn:ietf:params:jmap:calendars'],
       methodCalls: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import {
   McpError,
 } from '@modelcontextprotocol/sdk/types.js';
 import { FastmailAuth, FastmailConfig } from './auth.js';
-import { JmapClient } from './jmap-client.js';
+import { JmapClient, QueryResult } from './jmap-client.js';
 import { ContactsCalendarClient } from './contacts-calendar.js';
 import { CalDAVCalendarClient } from './caldav-client.js';
 import { coerceRecipients, coerceStringArray, coerceBool, redactBearerTokens, registerSecret } from './coerce.js';
@@ -137,6 +137,19 @@ function getDownloadDir(): string | undefined {
 // an unbounded/negative JMAP query).
 function clampLimit(value: unknown, fallback: number, max: number): number {
   return Math.min(Math.max(Number(value) || fallback, 1), max);
+}
+
+// When the JMAP server reports a total match count (calculateTotal: true), wrap
+// the items in a { total, items } envelope so callers can tell a truncated page
+// from a complete result. Without a total the bare array is returned unchanged,
+// keeping output byte-identical for paths that never had one (CalDAV, contacts
+// fallback).
+function formatQueryResult(result: QueryResult): string {
+  const { items, total } = result;
+  if (total != null) {
+    return JSON.stringify({ total, items }, null, 2);
+  }
+  return JSON.stringify(items, null, 2);
 }
 
 server.setRequestHandler(ListToolsRequestSchema, async () => {
@@ -1364,12 +1377,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case 'list_emails': {
         const { mailboxId, limit, ascending } = args as any;
         const validLimit = Math.min(Math.max(Number(limit) || 20, 1), 100);
-        const emails = await client.getEmails(mailboxId, validLimit, !!ascending);
+        const result = await client.getEmails(mailboxId, validLimit, !!ascending);
         return {
           content: [
             {
               type: 'text',
-              text: JSON.stringify(emails, null, 2),
+              text: formatQueryResult(result),
             },
           ],
         };
@@ -1629,12 +1642,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           throw new McpError(ErrorCode.InvalidParams, 'query is required');
         }
         const validLimit = Math.min(Math.max(Number(limit) || 20, 1), 100);
-        const emails = await client.searchEmails(query, validLimit, !!ascending, coerceBool(excludeDrafts) ?? false);
+        const result = await client.searchEmails(query, validLimit, !!ascending, coerceBool(excludeDrafts) ?? false);
         return {
           content: [
             {
               type: 'text',
-              text: JSON.stringify(emails, null, 2),
+              text: formatQueryResult(result),
             },
           ],
         };
@@ -1660,12 +1673,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case 'list_contacts': {
         const { limit } = args as any;
         const contactsClient = initializeContactsCalendarClient();
-        const contacts = await contactsClient.getContacts(clampLimit(limit, 50, 200));
+        const result = await contactsClient.getContacts(clampLimit(limit, 50, 200));
         return {
           content: [
             {
               type: 'text',
-              text: JSON.stringify(contacts, null, 2),
+              text: formatQueryResult(result),
             },
           ],
         };
@@ -1694,12 +1707,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           throw new McpError(ErrorCode.InvalidParams, 'query is required');
         }
         const contactsClient = initializeContactsCalendarClient();
-        const contacts = await contactsClient.searchContacts(query, clampLimit(limit, 20, 100));
+        const result = await contactsClient.searchContacts(query, clampLimit(limit, 20, 100));
         return {
           content: [
             {
               type: 'text',
-              text: JSON.stringify(contacts, null, 2),
+              text: formatQueryResult(result),
             },
           ],
         };
@@ -1817,12 +1830,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case 'get_recent_emails': {
         const { limit, mailboxName = null, ascending } = args as any;
         const client = initializeClient();
-        const emails = await client.getRecentEmails(clampLimit(limit, 10, 50), mailboxName, coerceBool(ascending) ?? false);
+        const result = await client.getRecentEmails(clampLimit(limit, 10, 50), mailboxName, coerceBool(ascending) ?? false);
         return {
           content: [
             {
               type: 'text',
-              text: JSON.stringify(emails, null, 2),
+              text: formatQueryResult(result),
             },
           ],
         };
@@ -2020,14 +2033,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const { query, from, to, subject, hasAttachment, isUnread, isPinned, mailboxId, requiredMailboxIds, excludeMailboxIds, after, before, limit, ascending } = args as any;
         const client = initializeClient();
         const validLimit = Math.min(Math.max(Number(limit) || 50, 1), 100);
-        const emails = await client.advancedSearch({
+        const result = await client.advancedSearch({
           query, from, to, subject, hasAttachment, isUnread, isPinned, mailboxId, requiredMailboxIds, excludeMailboxIds, after, before, limit: validLimit, ascending
         });
         return {
           content: [
             {
               type: 'text',
-              text: JSON.stringify(emails, null, 2),
+              text: formatQueryResult(result),
             },
           ],
         };
@@ -2313,8 +2326,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         
         // Get some recent emails to test with
         const testLimit = Math.min(Math.max(limit, 1), 10);
-        const emails = await client.getRecentEmails(testLimit, 'inbox');
-        
+        const { items: emails } = await client.getRecentEmails(testLimit, 'inbox');
+
         if (emails.length === 0) {
           return {
             content: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -207,7 +207,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: 'list_emails',
-        description: 'List emails from a mailbox',
+        description: 'List emails from a mailbox. When the server reports a total match count, results are wrapped in a {"total", "items"} JSON envelope; otherwise a bare JSON array is returned.',
         inputSchema: {
           type: 'object',
           properties: {
@@ -229,7 +229,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: 'list_emails_metadata',
-        description: 'Same as list_emails (lists emails from a mailbox, optionally filtered by mailboxId, with paging and sort) but returns ONLY metadata fields on each result — id, threadId, subject, from, to, replyTo, receivedAt, hasAttachment, keywords. Does NOT return preview or any body-derived content. Use in privacy-sensitive flows where the workflow needs only the envelope (e.g. customer-mail least-privilege scans, or any caller forbidden from ingesting message bodies). Pair with get_email_metadata for follow-up lookups that should also stay header-only.',
+        description: 'Same as list_emails (lists emails from a mailbox, optionally filtered by mailboxId, with paging and sort) but returns ONLY metadata fields on each result — id, threadId, subject, from, to, replyTo, receivedAt, hasAttachment, keywords. Does NOT return preview or any body-derived content. Use in privacy-sensitive flows where the workflow needs only the envelope (e.g. customer-mail least-privilege scans, or any caller forbidden from ingesting message bodies). Pair with get_email_metadata for follow-up lookups that should also stay header-only. When the server reports a total match count, results are wrapped in a {"total", "items"} JSON envelope; otherwise a bare JSON array is returned.',
         inputSchema: {
           type: 'object',
           properties: {
@@ -527,7 +527,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       {
         name: 'search_emails',
         description:
-          'Full-text search of email body and subject. Does not filter by sender, recipient, or date — use advanced_search for field-specific filtering. Drafts are included by default; set excludeDrafts=true to omit draft messages from results.',
+          'Full-text search of email body and subject. Does not filter by sender, recipient, or date — use advanced_search for field-specific filtering. Drafts are included by default; set excludeDrafts=true to omit draft messages from results. When the server reports a total match count, results are wrapped in a {"total", "items"} JSON envelope; otherwise a bare JSON array is returned.',
         inputSchema: {
           type: 'object',
           properties: {
@@ -554,7 +554,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: 'search_emails_metadata',
-        description: 'Same as search_emails (free-text search across subject and body) but returns ONLY metadata on each match — id, threadId, subject, from, to, replyTo, receivedAt, hasAttachment, keywords. The query still searches body text on the server side; only the result envelopes come back, never preview or body excerpts. Use when a content match is required (e.g. "find all messages mentioning X") but the matches must not surface body fragments to the caller.',
+        description: 'Same as search_emails (free-text search across subject and body) but returns ONLY metadata on each match — id, threadId, subject, from, to, replyTo, receivedAt, hasAttachment, keywords. The query still searches body text on the server side; only the result envelopes come back, never preview or body excerpts. Use when a content match is required (e.g. "find all messages mentioning X") but the matches must not surface body fragments to the caller. When the server reports a total match count, results are wrapped in a {"total", "items"} JSON envelope; otherwise a bare JSON array is returned.',
         inputSchema: {
           type: 'object',
           properties: {
@@ -577,7 +577,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: 'list_contacts',
-        description: 'List contacts from the address book',
+        description: 'List contacts from the address book. When the server reports a total match count, results are wrapped in a {"total", "items"} JSON envelope; otherwise a bare JSON array is returned.',
         inputSchema: {
           type: 'object',
           properties: {
@@ -605,7 +605,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: 'search_contacts',
-        description: 'Search contacts by name or email',
+        description: 'Search contacts by name or email. When the server reports a total match count, results are wrapped in a {"total", "items"} JSON envelope; otherwise a bare JSON array is returned.',
         inputSchema: {
           type: 'object',
           properties: {
@@ -795,7 +795,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: 'get_recent_emails',
-        description: 'Get the most recent emails across all mailboxes except Trash and Spam (pass mailboxName to scope to one folder, e.g. "inbox")',
+        description: 'Get the most recent emails across all mailboxes except Trash and Spam (pass mailboxName to scope to one folder, e.g. "inbox"). When the server reports a total match count, results are wrapped in a {"total", "items"} JSON envelope; otherwise a bare JSON array is returned.',
         inputSchema: {
           type: 'object',
           properties: {
@@ -979,7 +979,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: 'advanced_search',
-        description: 'Advanced email search with multiple criteria. Mailbox scoping supports a single mailbox (mailboxId), an intersection of multiple mailboxes (requiredMailboxIds — must be a member of ALL listed mailboxes), and exclusion (excludeMailboxIds — member of NONE of the listed mailboxes), alongside the standard sender / recipient / subject / free-text / date / attachment / unread / pinned filters.',
+        description: 'Advanced email search with multiple criteria. Mailbox scoping supports a single mailbox (mailboxId), an intersection of multiple mailboxes (requiredMailboxIds — must be a member of ALL listed mailboxes), and exclusion (excludeMailboxIds — member of NONE of the listed mailboxes), alongside the standard sender / recipient / subject / free-text / date / attachment / unread / pinned filters. When the server reports a total match count, results are wrapped in a {"total", "items"} JSON envelope; otherwise a bare JSON array is returned.',
         inputSchema: {
           type: 'object',
           properties: {
@@ -1047,7 +1047,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: 'advanced_search_metadata',
-        description: 'Same filter capabilities as advanced_search (single-mailbox scoping via mailboxId, multi-mailbox intersection via requiredMailboxIds, exclusion via excludeMailboxIds, plus sender / recipient / subject / free text / date / attachment / unread / pinned) but returns ONLY metadata on each match — id, threadId, subject, from, to, cc, replyTo, receivedAt, hasAttachment, keywords. Does NOT return preview or any body-derived content. Use in privacy-sensitive flows where the routing decision is made from headers alone — for example, when classifying customer mail by sender / recipient / subject / thread state without ingesting body content. The free-text query still searches body content on the server side; only the result envelope comes back without body excerpts.',
+        description: 'Same filter capabilities as advanced_search (single-mailbox scoping via mailboxId, multi-mailbox intersection via requiredMailboxIds, exclusion via excludeMailboxIds, plus sender / recipient / subject / free text / date / attachment / unread / pinned) but returns ONLY metadata on each match — id, threadId, subject, from, to, cc, replyTo, receivedAt, hasAttachment, keywords. Does NOT return preview or any body-derived content. Use in privacy-sensitive flows where the routing decision is made from headers alone — for example, when classifying customer mail by sender / recipient / subject / thread state without ingesting body content. The free-text query still searches body content on the server side; only the result envelope comes back without body excerpts. When the server reports a total match count, results are wrapped in a {"total", "items"} JSON envelope; otherwise a bare JSON array is returned.',
         inputSchema: {
           type: 'object',
           properties: {
@@ -1391,12 +1391,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case 'list_emails_metadata': {
         const { mailboxId, limit, ascending } = (args ?? {}) as any;
         const validLimit = Math.min(Math.max(Number(limit) || 20, 1), 100);
-        const emails = await client.getEmailsMetadata(mailboxId, validLimit, !!ascending);
+        const result = await client.getEmailsMetadata(mailboxId, validLimit, !!ascending);
         return {
           content: [
             {
               type: 'text',
-              text: JSON.stringify(emails, null, 2),
+              text: formatQueryResult(result),
             },
           ],
         };
@@ -1659,12 +1659,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           throw new McpError(ErrorCode.InvalidParams, 'query is required');
         }
         const validLimit = Math.min(Math.max(Number(limit) || 20, 1), 100);
-        const emails = await client.searchEmailsMetadata(query, validLimit, !!ascending);
+        const result = await client.searchEmailsMetadata(query, validLimit, !!ascending);
         return {
           content: [
             {
               type: 'text',
-              text: JSON.stringify(emails, null, 2),
+              text: formatQueryResult(result),
             },
           ],
         };
@@ -2050,14 +2050,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const { query, from, to, subject, hasAttachment, isUnread, isPinned, mailboxId, requiredMailboxIds, excludeMailboxIds, after, before, limit, ascending } = (args ?? {}) as any;
         const client = initializeClient();
         const validLimit = Math.min(Math.max(Number(limit) || 50, 1), 100);
-        const emails = await client.advancedSearchMetadata({
+        const result = await client.advancedSearchMetadata({
           query, from, to, subject, hasAttachment, isUnread, isPinned, mailboxId, requiredMailboxIds, excludeMailboxIds, after, before, limit: validLimit, ascending
         });
         return {
           content: [
             {
               type: 'text',
-              text: JSON.stringify(emails, null, 2),
+              text: formatQueryResult(result),
             },
           ],
         };

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import { coerceRecipients, coerceStringArray, coerceBool, redactBearerTokens, re
 const server = new Server(
   {
     name: 'fastmail-mcp',
-    version: '1.11.1',
+    version: '1.12.0',
   },
   {
     capabilities: {

--- a/src/jmap-client-extra.test.ts
+++ b/src/jmap-client-extra.test.ts
@@ -87,9 +87,9 @@ describe('getRecentEmails', () => {
       ],
     });
 
-    const emails = await client.getRecentEmails(10, 'inbox');
-    assert.equal(emails.length, 2);
-    assert.equal(emails[0].subject, 'First');
+    const result = await client.getRecentEmails(10, 'inbox');
+    assert.equal(result.items.length, 2);
+    assert.equal(result.items[0].subject, 'First');
   });
 
   it('throws when mailbox is not found', async () => {
@@ -113,8 +113,8 @@ describe('getRecentEmails', () => {
       ],
     });
 
-    const emails = await client.getRecentEmails(5, 'inbox');
-    assert.deepEqual(emails, []);
+    const result = await client.getRecentEmails(5, 'inbox');
+    assert.deepEqual(result.items, []);
   });
 
   it('defaults to all mailboxes except Trash and Spam when no mailbox is given', async () => {
@@ -185,8 +185,8 @@ describe('getEmails', () => {
       ],
     }));
 
-    const emails = await client.getEmails('mb-inbox', 5);
-    assert.equal(emails.length, 1);
+    const result = await client.getEmails('mb-inbox', 5);
+    assert.equal(result.items.length, 1);
 
     const filter = makeReq.mock.calls[0].arguments[0].methodCalls[0][1].filter;
     assert.equal(filter.inMailbox, 'mb-inbox');
@@ -200,8 +200,8 @@ describe('getEmails', () => {
       ],
     }));
 
-    const emails = await client.getEmails(undefined, 10);
-    assert.equal(emails.length, 1);
+    const result = await client.getEmails(undefined, 10);
+    assert.equal(result.items.length, 1);
 
     const filter = makeReq.mock.calls[0].arguments[0].methodCalls[0][1].filter;
     assert.deepEqual(filter, {});

--- a/src/jmap-client-extra.test.ts
+++ b/src/jmap-client-extra.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, beforeEach, mock } from 'node:test';
 import assert from 'node:assert/strict';
 import { JmapClient, buildEmailQueryFilter } from './jmap-client.js';
+import { ContactsCalendarClient } from './contacts-calendar.js';
 import { FastmailAuth } from './auth.js';
 
 // ---------- helpers ----------
@@ -1036,5 +1037,135 @@ describe('getThread draft handling', () => {
     const thread = await client.getThread('e1', true);
     assert.equal(thread.length, 2);
     assert.deepEqual(thread.map((e: any) => e.id), ['e1', 'e2']);
+  });
+});
+
+// ---------- total result count (calculateTotal / QueryResult) ----------
+
+describe('query total result count', () => {
+  let client: JmapClient;
+
+  beforeEach(() => {
+    client = makeClient();
+  });
+
+  it('getEmails requests calculateTotal on Email/query', async () => {
+    const makeReq = mock.method(client, 'makeRequest', async () => ({
+      methodResponses: [
+        ['Email/query', { ids: [] }, 'query'],
+        ['Email/get', { list: [] }, 'emails'],
+      ],
+    }));
+
+    await client.getEmails('mb-inbox', 5);
+
+    assert.equal(makeReq.mock.calls[0].arguments[0].methodCalls[0][1].calculateTotal, true);
+  });
+
+  it('surfaces the server-reported total alongside the items', async () => {
+    stubMakeRequest(client, {
+      methodResponses: [
+        ['Email/query', { ids: ['e1'], total: 42 }, 'query'],
+        ['Email/get', { list: [{ id: 'e1', subject: 'Only one fetched' }] }, 'emails'],
+      ],
+    });
+
+    const result = await client.getEmails('mb-inbox', 1);
+    assert.equal(result.total, 42);
+    assert.equal(result.items.length, 1);
+  });
+
+  it('omits total when the server does not report one', async () => {
+    stubMakeRequest(client, {
+      methodResponses: [
+        ['Email/query', { ids: ['e1'] }, 'query'],
+        ['Email/get', { list: [{ id: 'e1' }] }, 'emails'],
+      ],
+    });
+
+    const result = await client.getEmails('mb-inbox', 1);
+    assert.equal('total' in result, false);
+    assert.equal(result.items.length, 1);
+  });
+
+  it('metadata variants request and surface the total without widening the property allowlist', async () => {
+    const makeReq = mock.method(client, 'makeRequest', async () => ({
+      methodResponses: [
+        ['Email/query', { ids: ['e1'], total: 7 }, 'query'],
+        ['Email/get', { list: [{ id: 'e1', subject: 'Meta' }] }, 'emails'],
+      ],
+    }));
+
+    const result = await client.getEmailsMetadata('mb-inbox', 1);
+
+    assert.equal(makeReq.mock.calls[0].arguments[0].methodCalls[0][1].calculateTotal, true);
+    assert.equal(result.total, 7);
+    const props = makeReq.mock.calls[0].arguments[0].methodCalls[1][1].properties;
+    assert.equal(props.includes('preview'), false);
+    assert.equal(props.some((p: string) => p.startsWith('body')), false);
+  });
+
+  it('searchEmails and advancedSearch surface the total', async () => {
+    stubMakeRequest(client, {
+      methodResponses: [
+        ['Email/query', { ids: ['e1'], total: 99 }, 'query'],
+        ['Email/get', { list: [{ id: 'e1' }] }, 'emails'],
+      ],
+    });
+
+    const search = await client.searchEmails('test', 1);
+    assert.equal(search.total, 99);
+
+    const advanced = await client.advancedSearch({ query: 'test', limit: 1 });
+    assert.equal(advanced.total, 99);
+  });
+});
+
+describe('getContacts total result count', () => {
+  function makeContactsClient(): ContactsCalendarClient {
+    const auth = new FastmailAuth({ apiToken: 'fake-token' });
+    const client = new ContactsCalendarClient(auth);
+
+    mock.method(client, 'getSession', async () => ({
+      apiUrl: 'https://api.example.com/jmap/api/',
+      accountId: ACCOUNT_ID,
+      capabilities: { 'urn:ietf:params:jmap:contacts': {} },
+    }));
+
+    return client;
+  }
+
+  it('surfaces the total from ContactCard/query', async () => {
+    const client = makeContactsClient();
+    stubMakeRequest(client, {
+      methodResponses: [
+        ['ContactCard/query', { ids: ['c1'], total: 250 }, 'query'],
+        ['ContactCard/get', { list: [{ id: 'c1', name: 'Test Person' }] }, 'contacts'],
+      ],
+    });
+
+    const result = await client.getContacts(1);
+    assert.equal(result.total, 250);
+    assert.equal(result.items.length, 1);
+  });
+
+  it('AddressBook fallback returns items without a total', async () => {
+    const client = makeContactsClient();
+    let call = 0;
+    mock.method(client, 'makeRequest', async () => {
+      call += 1;
+      if (call === 1) {
+        throw new Error('ContactCard/query not supported');
+      }
+      return {
+        methodResponses: [
+          ['AddressBook/get', { list: [{ id: 'ab1', name: 'Default' }] }, 'addressbooks'],
+        ],
+      };
+    });
+
+    const result = await client.getContacts(10);
+    assert.equal('total' in result, false);
+    assert.equal(result.items.length, 1);
   });
 });

--- a/src/jmap-client.test.ts
+++ b/src/jmap-client.test.ts
@@ -646,8 +646,8 @@ describe('searchEmails', () => {
       ],
     });
     const results = await client.searchEmails('test', 10);
-    assert.equal(results.length, 1);
-    assert.equal(results[0].subject, 'Test');
+    assert.equal(results.items.length, 1);
+    assert.equal(results.items[0].subject, 'Test');
   });
 
   it('returns empty array when no results', async () => {
@@ -658,7 +658,7 @@ describe('searchEmails', () => {
       ],
     });
     const results = await client.searchEmails('nonexistent');
-    assert.deepEqual(results, []);
+    assert.deepEqual(results.items, []);
   });
 
   it('throws on JMAP error in query', async () => {

--- a/src/jmap-client.test.ts
+++ b/src/jmap-client.test.ts
@@ -605,7 +605,7 @@ describe('JMAP response validation', () => {
         ['error', { type: 'serverFail', description: 'oops' }, 'query'],
       ],
     });
-    // getEmails uses getListResult(response, 1) but only 1 response exists
+    // getEmails uses getQueryResult(response, 0, 1) and the error sits at index 0
     await assert.rejects(
       () => client.getEmails(undefined, 10),
       (err: Error) => {

--- a/src/jmap-client.ts
+++ b/src/jmap-client.ts
@@ -130,6 +130,11 @@ export function buildEmailQueryFilter(filters: EmailQueryFilters): any {
   return { operator: 'AND', conditions };
 }
 
+export interface QueryResult<T = any> {
+  items: T[];
+  total?: number;
+}
+
 export class JmapClient {
   private auth: FastmailAuth;
   private session: JmapSession | null = null;
@@ -164,6 +169,17 @@ export class JmapClient {
   protected getListResult(response: JmapResponse, index: number): any[] {
     const result = this.getMethodResult(response, index);
     return result?.list || [];
+  }
+
+  /**
+   * Build a QueryResult from a query + get pair.
+   * queryIndex is the /query response; listIndex is the /get response.
+   */
+  protected getQueryResult(response: JmapResponse, queryIndex: number, listIndex: number): QueryResult {
+    const queryResult = this.getMethodResult(response, queryIndex);
+    const items = this.getListResult(response, listIndex);
+    const total = queryResult?.total;
+    return total != null ? { items, total } : { items };
   }
 
   async getSession(): Promise<JmapSession> {
@@ -335,7 +351,7 @@ export class JmapClient {
     return created.id;
   }
 
-  async getEmails(mailboxId?: string, limit: number = 20, ascending: boolean = false): Promise<any[]> {
+  async getEmails(mailboxId?: string, limit: number = 20, ascending: boolean = false): Promise<QueryResult> {
     const session = await this.getSession();
 
     const filter = mailboxId ? { inMailbox: mailboxId } : {};
@@ -347,7 +363,8 @@ export class JmapClient {
           accountId: session.accountId,
           filter,
           sort: [{ property: 'receivedAt', isAscending: ascending }],
-          limit
+          limit,
+          calculateTotal: true
         }, 'query'],
         ['Email/get', {
           accountId: session.accountId,
@@ -358,7 +375,7 @@ export class JmapClient {
     };
 
     const response = await this.makeRequest(request);
-    return this.getListResult(response, 1);
+    return this.getQueryResult(response, 0, 1);
   }
 
   async getEmailsMetadata(mailboxId?: string, limit: number = 20, ascending: boolean = false): Promise<any[]> {
@@ -976,7 +993,7 @@ export class JmapClient {
     return submissionId;
   }
 
-  async getRecentEmails(limit: number = 10, mailboxName: string | null = null, ascending: boolean = false): Promise<any[]> {
+  async getRecentEmails(limit: number = 10, mailboxName: string | null = null, ascending: boolean = false): Promise<QueryResult> {
     const session = await this.getSession();
 
     const mailboxes = await this.getMailboxes();
@@ -1008,7 +1025,8 @@ export class JmapClient {
           accountId: session.accountId,
           filter,
           sort: [{ property: 'receivedAt', isAscending: ascending }],
-          limit: Math.min(limit, 50)
+          limit: Math.min(limit, 50),
+          calculateTotal: true
         }, 'query'],
         ['Email/get', {
           accountId: session.accountId,
@@ -1019,7 +1037,7 @@ export class JmapClient {
     };
 
     const response = await this.makeRequest(request);
-    return this.getListResult(response, 1);
+    return this.getQueryResult(response, 0, 1);
   }
 
   async markEmailRead(emailId: string, read: boolean = true): Promise<void> {
@@ -1541,7 +1559,7 @@ export class JmapClient {
     return { url, bytesWritten: buffer.length, savedPath: safePath };
   }
 
-  async advancedSearch(filters: EmailQueryFilters): Promise<any[]> {
+  async advancedSearch(filters: EmailQueryFilters): Promise<QueryResult> {
     const session = await this.getSession();
     const finalFilter = buildEmailQueryFilter(filters);
 
@@ -1552,7 +1570,8 @@ export class JmapClient {
           accountId: session.accountId,
           filter: finalFilter,
           sort: [{ property: 'receivedAt', isAscending: filters.ascending ?? false }],
-          limit: Math.min(filters.limit || 50, 100)
+          limit: Math.min(filters.limit || 50, 100),
+          calculateTotal: true
         }, 'query'],
         ['Email/get', {
           accountId: session.accountId,
@@ -1563,7 +1582,7 @@ export class JmapClient {
     };
 
     const response = await this.makeRequest(request);
-    return this.getListResult(response, 1);
+    return this.getQueryResult(response, 0, 1);
   }
 
   async advancedSearchMetadata(filters: EmailQueryFilters): Promise<any[]> {
@@ -1591,7 +1610,7 @@ export class JmapClient {
     return this.getListResult(response, 1);
   }
 
-  async searchEmails(query: string, limit: number = 20, ascending: boolean = false, excludeDrafts: boolean = false): Promise<any[]> {
+  async searchEmails(query: string, limit: number = 20, ascending: boolean = false, excludeDrafts: boolean = false): Promise<QueryResult> {
     const session = await this.getSession();
 
     // A JMAP FilterCondition ANDs its properties, so text + notKeyword means
@@ -1606,7 +1625,8 @@ export class JmapClient {
           accountId: session.accountId,
           filter,
           sort: [{ property: 'receivedAt', isAscending: ascending }],
-          limit
+          limit,
+          calculateTotal: true
         }, 'query'],
         ['Email/get', {
           accountId: session.accountId,
@@ -1617,7 +1637,7 @@ export class JmapClient {
     };
 
     const response = await this.makeRequest(request);
-    return this.getListResult(response, 1);
+    return this.getQueryResult(response, 0, 1);
   }
 
   async searchEmailsMetadata(query: string, limit: number = 20, ascending: boolean = false): Promise<any[]> {

--- a/src/jmap-client.ts
+++ b/src/jmap-client.ts
@@ -378,7 +378,7 @@ export class JmapClient {
     return this.getQueryResult(response, 0, 1);
   }
 
-  async getEmailsMetadata(mailboxId?: string, limit: number = 20, ascending: boolean = false): Promise<any[]> {
+  async getEmailsMetadata(mailboxId?: string, limit: number = 20, ascending: boolean = false): Promise<QueryResult> {
     const session = await this.getSession();
 
     const filter = mailboxId ? { inMailbox: mailboxId } : {};
@@ -390,7 +390,8 @@ export class JmapClient {
           accountId: session.accountId,
           filter,
           sort: [{ property: 'receivedAt', isAscending: ascending }],
-          limit
+          limit,
+          calculateTotal: true
         }, 'query'],
         ['Email/get', {
           accountId: session.accountId,
@@ -401,7 +402,7 @@ export class JmapClient {
     };
 
     const response = await this.makeRequest(request);
-    return this.getListResult(response, 1);
+    return this.getQueryResult(response, 0, 1);
   }
 
   async getEmailById(id: string): Promise<any> {
@@ -1585,7 +1586,7 @@ export class JmapClient {
     return this.getQueryResult(response, 0, 1);
   }
 
-  async advancedSearchMetadata(filters: EmailQueryFilters): Promise<any[]> {
+  async advancedSearchMetadata(filters: EmailQueryFilters): Promise<QueryResult> {
     const session = await this.getSession();
     const finalFilter = buildEmailQueryFilter(filters);
 
@@ -1596,7 +1597,8 @@ export class JmapClient {
           accountId: session.accountId,
           filter: finalFilter,
           sort: [{ property: 'receivedAt', isAscending: filters.ascending ?? false }],
-          limit: Math.min(filters.limit || 50, 100)
+          limit: Math.min(filters.limit || 50, 100),
+          calculateTotal: true
         }, 'query'],
         ['Email/get', {
           accountId: session.accountId,
@@ -1607,7 +1609,7 @@ export class JmapClient {
     };
 
     const response = await this.makeRequest(request);
-    return this.getListResult(response, 1);
+    return this.getQueryResult(response, 0, 1);
   }
 
   async searchEmails(query: string, limit: number = 20, ascending: boolean = false, excludeDrafts: boolean = false): Promise<QueryResult> {
@@ -1640,7 +1642,7 @@ export class JmapClient {
     return this.getQueryResult(response, 0, 1);
   }
 
-  async searchEmailsMetadata(query: string, limit: number = 20, ascending: boolean = false): Promise<any[]> {
+  async searchEmailsMetadata(query: string, limit: number = 20, ascending: boolean = false): Promise<QueryResult> {
     const session = await this.getSession();
 
     const request: JmapRequest = {
@@ -1650,7 +1652,8 @@ export class JmapClient {
           accountId: session.accountId,
           filter: { text: query },
           sort: [{ property: 'receivedAt', isAscending: ascending }],
-          limit
+          limit,
+          calculateTotal: true
         }, 'query'],
         ['Email/get', {
           accountId: session.accountId,
@@ -1661,7 +1664,7 @@ export class JmapClient {
     };
 
     const response = await this.makeRequest(request);
-    return this.getListResult(response, 1);
+    return this.getQueryResult(response, 0, 1);
   }
 
   async getThread(threadId: string, includeDrafts: boolean = false): Promise<any[]> {


### PR DESCRIPTION
Integration of #49 by @JonathanGodley, rebased onto current main (the original was based on v1.9.1, ~40 commits behind) and extended to the query tools added since. Closes #49.

## What's here

- **Commit 1** (cherry-pick, Jonathan's authorship preserved): `QueryResult { items, total? }`, a protected `getQueryResult()` helper, and `calculateTotal: true` on the JMAP queries behind `list_emails`, `search_emails`, `advanced_search`, `get_recent_emails`, `list_contacts`, `search_contacts`.
- **Commit 2**: extends the same pattern to `list_emails_metadata`, `search_emails_metadata`, `advanced_search_metadata` (their `Email/get` property allowlists are untouched), adds 7 feature tests, and documents the new shape in the 9 tool descriptions.
- **Commit 3**: version bump to v1.12.0 (package.json / manifest.json / index.ts, enforced by the version-sync test).

## Output shape

Instead of the original summary-line prefix, results are wrapped in a parseable JSON envelope only when the server reports a total — `{"total": 123, "items": [...]}` — and stay a bare JSON array otherwise, so non-JMAP paths (CalDAV, contacts AddressBook fallback) are byte-identical to before.

## Deliberate adjustments from the original #49

- Kept main's newer behavior everywhere the rebase touched it: `searchEmails` draft filtering (#80), `getRecentEmails` all-mail default (06d333a), `buildEmailQueryFilter` with multi-mailbox AND/exclusion (#71), and main's `clampLimit` caps (the original's 50→100 `list_emails` bump had already landed).
- Dropped the JMAP-calendar wiring for `list_calendar_events`: that path is disabled on main ("known bugs, must not be used") and CalDAV reports no server-side total.

## Verification

- 386/386 tests pass (typecheck clean under both TS 6.0.3 and 7.0.2), secret scan clean.
- MCP protocol smoke: server boots, `initialize` + `tools/list` OK, envelope documented on exactly the 9 converted tools.
- Adversarial multi-agent review (regression-vs-main, correctness, consumers, security lenses): no findings.

Thanks @JonathanGodley for the feature and the clean mechanism — the core design here is yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)