### PR TITLE
ci: auto-generate release notes on tagged releases

### DIFF
--- a/.github/workflows/build-dxt.yml
+++ b/.github/workflows/build-dxt.yml
@@ -52,5 +52,8 @@ jobs:
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           files: ${{ env.DXT_FILE }}
+          # Seed the release body with the auto-generated PR list so new
+          # releases never publish empty; hand-written notes can replace it.
+          generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
v1.12.0 published with an empty body because the `action-gh-release` step in `build-dxt.yml` supplies no notes. Add `generate_release_notes: true` so every tagged release is seeded with GitHub's auto-generated PR list — hand-written notes can still replace it afterward (as was done for v1.12.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)