### PR TITLE
fix: single-item getters throw not-found instead of returning null

### DIFF
--- a/src/caldav-client.test.ts
+++ b/src/caldav-client.test.ts
@@ -622,6 +622,46 @@ describe('CalDAVCalendarClient.deleteCalendarEvent', () => {
   });
 });
 
+describe('CalDAVCalendarClient.getCalendarEventById', () => {
+  function createMockedClientWithObjects(calendarObjects: Array<{ data: string; url: string; etag?: string }>) {
+    const client = new CalDAVCalendarClient({ username: 'test', password: 'test' });
+    const mockDAVClient = {
+      login: mock.fn(async () => {}),
+      fetchCalendars: mock.fn(async () => [
+        { displayName: 'Personal', url: '/cal/personal/' },
+      ]),
+      fetchCalendarObjects: mock.fn(async () => calendarObjects),
+    };
+    (client as any).client = mockDAVClient;
+    return { client, mockDAVClient };
+  }
+
+  it('returns the parsed event when the UID exists', async () => {
+    const ical = [
+      'BEGIN:VCALENDAR',
+      'BEGIN:VEVENT',
+      'UID:get1@fm',
+      'DTSTART:20260401T100000Z',
+      'SUMMARY:Findable',
+      'END:VEVENT',
+      'END:VCALENDAR',
+    ].join('\r\n');
+    const { client } = createMockedClientWithObjects([{ data: ical, url: '/cal/get1.ics', etag: '"etag1"' }]);
+
+    const event = await client.getCalendarEventById('get1@fm');
+    assert.equal(event.id, 'get1@fm');
+    assert.equal(event.title, 'Findable');
+  });
+
+  it('throws instead of returning null when the event does not exist', async () => {
+    const { client } = createMockedClientWithObjects([]);
+    await assert.rejects(
+      () => client.getCalendarEventById('nonexistent@fm'),
+      /Calendar event not found: nonexistent@fm/
+    );
+  });
+});
+
 // ============================================================
 // New tests for calendar attendee support & non-destructive updates
 // ============================================================

--- a/src/caldav-client.ts
+++ b/src/caldav-client.ts
@@ -1096,9 +1096,15 @@ export class CalDAVCalendarClient {
     return null;
   }
 
-  async getCalendarEventById(eventId: string): Promise<CalendarEvent | null> {
+  async getCalendarEventById(eventId: string): Promise<CalendarEvent> {
     const obj = await this.findCalendarObjectByUID(eventId);
-    return obj ? parseCalendarObject(obj, { includeParticipants: true }) : null;
+    // Throw rather than return null so the MCP tool surfaces a real not-found
+    // error — matches updateCalendarEvent/deleteCalendarEvent below. A null
+    // here used to reach callers as a successful "null" tool response.
+    if (!obj) {
+      throw new Error(`Calendar event not found: ${eventId}`);
+    }
+    return parseCalendarObject(obj, { includeParticipants: true });
   }
 
   async createCalendarEvent(event: {

--- a/src/contacts-calendar.ts
+++ b/src/contacts-calendar.ts
@@ -81,12 +81,19 @@ export class ContactsCalendarClient extends JmapClient {
       ]
     };
 
+    let contact;
     try {
       const response = await this.makeRequest(request);
-      return this.getListResult(response, 0)[0];
+      contact = this.getListResult(response, 0)[0];
     } catch (error) {
       throw new Error(`Contact access not supported: ${error instanceof Error ? error.message : String(error)}. Try checking account permissions or enabling contacts API access in Fastmail settings.`);
     }
+    // ContactCard/get reports unknown ids via notFound, leaving list empty — a
+    // bare undefined here used to serialize as a successful empty tool response.
+    if (!contact) {
+      throw new Error(`Contact not found: ${id}`);
+    }
+    return contact;
   }
 
   async searchContacts(query: string, limit: number = 20): Promise<QueryResult> {

--- a/src/jmap-client-extra.test.ts
+++ b/src/jmap-client-extra.test.ts
@@ -1169,3 +1169,44 @@ describe('getContacts total result count', () => {
     assert.equal(result.items.length, 1);
   });
 });
+
+describe('getContactById not-found', () => {
+  function makeContactsClient(): ContactsCalendarClient {
+    const auth = new FastmailAuth({ apiToken: 'fake-token' });
+    const client = new ContactsCalendarClient(auth);
+
+    mock.method(client, 'getSession', async () => ({
+      apiUrl: 'https://api.example.com/jmap/api/',
+      accountId: ACCOUNT_ID,
+      capabilities: { 'urn:ietf:params:jmap:contacts': {} },
+    }));
+
+    return client;
+  }
+
+  it('returns the contact when it exists', async () => {
+    const client = makeContactsClient();
+    stubMakeRequest(client, {
+      methodResponses: [
+        ['ContactCard/get', { list: [{ id: 'c1', name: 'Real Person' }] }, 'contact'],
+      ],
+    });
+
+    const contact = await client.getContactById('c1');
+    assert.equal(contact.id, 'c1');
+  });
+
+  it('throws instead of returning undefined for an unknown id', async () => {
+    const client = makeContactsClient();
+    stubMakeRequest(client, {
+      methodResponses: [
+        ['ContactCard/get', { list: [], notFound: ['ghost'] }, 'contact'],
+      ],
+    });
+
+    await assert.rejects(
+      () => client.getContactById('ghost'),
+      /Contact not found: ghost/
+    );
+  });
+});


### PR DESCRIPTION
Live integration testing of v1.12.0 found that `get_calendar_event` with a nonexistent/deleted `eventId` returns a **successful** response whose text is the literal string `null` (`isError: false`), and `get_contact` serializes `undefined` for unknown ids. AI callers can misread both as valid results.

## Changes

- `CalDAVCalendarClient.getCalendarEventById` now throws `Calendar event not found: <id>` — the same contract as its `updateCalendarEvent`/`deleteCalendarEvent` siblings, surfaced to MCP callers as a proper error through the existing redaction choke point.
- `ContactsCalendarClient.getContactById` now throws `Contact not found: <id>` when `ContactCard/get` reports the id in `notFound` (check deliberately placed outside the access-error wrapper so it isn't misreported as a permissions problem).

## Surveyed and already correct

`getEmailById`, `getEmailMetadata`, and `getMailboxByName` already throw on miss. `get_thread` returns an empty array for an unknown thread id — list-shaped output, left unchanged.

## Verification

- 390/390 unit tests (4 new: hit + miss for each fixed getter), TS7 typecheck, secret scan clean.
- Live check against a real account: the previously-`null` lookup now returns `MCP error -32603: Tool execution failed: Calendar event not found: <id>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)