### PR TITLE
feat: save_attachment_to_webdav — attachments to cloud storage

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,8 @@ import { FastmailAuth, FastmailConfig } from './auth.js';
 import { JmapClient, QueryResult } from './jmap-client.js';
 import { ContactsCalendarClient } from './contacts-calendar.js';
 import { CalDAVCalendarClient } from './caldav-client.js';
+import { WebDAVFilesClient } from './webdav-files-client.js';
+import { validateHttpsUrl } from './url-validation.js';
 import { coerceRecipients, coerceStringArray, coerceBool, redactBearerTokens, registerSecret } from './coerce.js';
 
 const server = new Server(
@@ -121,6 +123,36 @@ function initializeCalDAVClient(): CalDAVCalendarClient | null {
 
   caldavClient = new CalDAVCalendarClient({ username, password });
   return caldavClient;
+}
+
+let webdavClient: WebDAVFilesClient | null = null;
+
+function initializeWebDAVClient(): WebDAVFilesClient | null {
+  if (webdavClient) return webdavClient;
+
+  const baseUrl = findEnvValue([
+    'FASTMAIL_WEBDAV_URL',
+    'USER_CONFIG_FASTMAIL_WEBDAV_URL',
+  ]).value;
+  const username = findEnvValue([
+    'FASTMAIL_WEBDAV_USERNAME',
+    'USER_CONFIG_FASTMAIL_WEBDAV_USERNAME',
+  ]).value;
+  const password = findEnvValue([
+    'FASTMAIL_WEBDAV_PASSWORD',
+    'USER_CONFIG_FASTMAIL_WEBDAV_PASSWORD',
+  ]).value;
+
+  if (!baseUrl || !username || !password) return null;
+
+  // The base URL is server config, never a tool argument — tools may only
+  // supply relative paths beneath it. HTTPS-only, no embedded credentials.
+  validateHttpsUrl(baseUrl, 'FASTMAIL_WEBDAV_URL');
+  registerSecret(password);
+  registerSecret(username);
+
+  webdavClient = new WebDAVFilesClient({ baseUrl, username, password });
+  return webdavClient;
 }
 
 function getDownloadDir(): string | undefined {
@@ -1035,6 +1067,36 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
           },
           required: ['emailId', 'attachmentId'],
+        },
+      },
+      {
+        name: 'save_attachment_to_webdav',
+        description: 'Save an email attachment directly to WebDAV cloud storage (e.g. Fastmail Files or Nextcloud) without touching local disk. The storage server and credentials come from server configuration (FASTMAIL_WEBDAV_URL / _USERNAME / _PASSWORD); this tool only chooses the relative path beneath that base. Fails if the remote file exists unless overwrite is set.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            emailId: {
+              type: 'string',
+              description: 'ID of the email',
+            },
+            attachmentId: {
+              type: 'string',
+              description: 'Attachment partId, blobId, or zero-based index',
+            },
+            remotePath: {
+              type: 'string',
+              description: 'Relative path under the configured WebDAV base (e.g. "invoices/2026/receipt.pdf"). No leading slash, no "..", forward slashes only. Missing parent folders are created unless createParents is false.',
+            },
+            overwrite: {
+              type: 'boolean',
+              description: 'Replace an existing remote file (default false: fail if it exists)',
+            },
+            createParents: {
+              type: 'boolean',
+              description: 'Create missing parent collections via MKCOL (default true)',
+            },
+          },
+          required: ['emailId', 'attachmentId', 'remotePath'],
         },
       },
       {
@@ -2095,6 +2157,35 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             'Attachment download failed. Verify emailId and attachmentId and try again.'
           );
         }
+      }
+
+      case 'save_attachment_to_webdav': {
+        const { emailId, attachmentId, remotePath, overwrite, createParents } = args as any;
+        if (!emailId || !attachmentId) {
+          throw new McpError(ErrorCode.InvalidParams, 'emailId and attachmentId are required');
+        }
+        if (!remotePath) {
+          throw new McpError(ErrorCode.InvalidParams, 'remotePath is required');
+        }
+        const dav = initializeWebDAVClient();
+        if (!dav) {
+          throw new McpError(ErrorCode.InvalidRequest, 'WebDAV storage not configured. Set FASTMAIL_WEBDAV_URL, FASTMAIL_WEBDAV_USERNAME, and FASTMAIL_WEBDAV_PASSWORD (for Fastmail Files use https://myfiles.fastmail.com/ with a Files-scoped app password).');
+        }
+        const client = initializeClient();
+        const { buffer, type, name } = await client.fetchAttachmentBuffer(emailId, attachmentId);
+        const result = await dav.uploadBuffer(buffer, remotePath, {
+          contentType: type,
+          overwrite: coerceBool(overwrite) ?? false,
+          createParents: coerceBool(createParents) ?? true,
+        });
+        return {
+          content: [
+            {
+              type: 'text',
+              text: redactBearerTokens(JSON.stringify({ ...result, attachmentName: name }, null, 2)),
+            },
+          ],
+        };
       }
 
       case 'advanced_search': {

--- a/src/url-validation.ts
+++ b/src/url-validation.ts
@@ -44,3 +44,36 @@ export function validateFastmailUrl(input: string, fieldName: string, allowUnsaf
 }
 
 export const FASTMAIL_ALLOWED_HOSTS_FOR_TEST = FASTMAIL_ALLOWED_HOSTS;
+
+/**
+ * Validate a user-configured HTTPS endpoint (e.g. the WebDAV base URL).
+ *
+ * Unlike validateFastmailUrl there is deliberately NO host allowlist — the
+ * host being user-chosen is the point (Fastmail Files, Nextcloud, ...), and
+ * the value comes from server env, never from tool arguments. Enforced:
+ *   - HTTPS only (credentials travel with every request).
+ *   - No embedded userinfo (credentials belong in the Authorization header,
+ *     not in a URL that ends up in logs and error messages).
+ *   - No query or fragment (a collection URL has neither; their presence
+ *     signals a copy-paste mistake or something more creative).
+ *
+ * Throws on rejection; returns the parsed URL on success.
+ */
+export function validateHttpsUrl(input: string, fieldName: string): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(input);
+  } catch {
+    throw new Error(`${fieldName} is not a valid URL`);
+  }
+  if (parsed.protocol !== 'https:') {
+    throw new Error(`${fieldName} must use HTTPS (got: ${parsed.protocol}).`);
+  }
+  if (parsed.username || parsed.password) {
+    throw new Error(`${fieldName} must not embed credentials in the URL; use the username/password settings.`);
+  }
+  if (parsed.search || parsed.hash) {
+    throw new Error(`${fieldName} must be a plain collection URL without query or fragment.`);
+  }
+  return parsed;
+}

--- a/src/webdav-files-client.test.ts
+++ b/src/webdav-files-client.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { WebDAVFilesClient, sanitizeRemotePath } from './webdav-files-client.js';
+import { validateHttpsUrl } from './url-validation.js';
+
+// ---------- sanitizeRemotePath ----------
+
+describe('sanitizeRemotePath', () => {
+  it('accepts clean nested paths and returns raw segments', () => {
+    assert.deepEqual(sanitizeRemotePath('invoices/2026/receipt.pdf'), ['invoices', '2026', 'receipt.pdf']);
+    assert.deepEqual(sanitizeRemotePath('file.txt'), ['file.txt']);
+    assert.deepEqual(sanitizeRemotePath('name with spaces & symbols!.txt'), ['name with spaces & symbols!.txt']);
+  });
+
+  const rejects: Array<[string, any, RegExp]> = [
+    ['empty', '', /required/],
+    ['absolute path', '/etc/passwd', /relative/],
+    ['parent traversal', '../secrets.txt', /\.\. segments|must not contain/],
+    ['embedded traversal', 'a/../../b', /must not contain/],
+    ['dot segment', 'a/./b', /must not contain/],
+    ['double slash', 'a//b', /empty segment/],
+    ['trailing slash', 'a/b/', /empty segment/],
+    ['backslash', 'a\\b.txt', /forward slashes/],
+    ['URL smuggling', 'https://evil.example/x', /not a URL/],
+    ['NUL byte', 'a\u0000b', /control characters/],
+    ['newline', 'a\nb', /control characters/],
+    ['DEL char', 'a\u007fb', /control characters/],
+    ['overlong path', 'x'.repeat(1025), /too long/],
+    ['too many segments', Array(33).fill('d').join('/'), /too many segments/],
+    ['overlong segment', 'y'.repeat(256), /255 bytes/],
+  ];
+  for (const [label, input, pattern] of rejects) {
+    it(`rejects ${label}`, () => {
+      assert.throws(() => sanitizeRemotePath(input), pattern);
+    });
+  }
+
+  it('percent-encoded traversal survives as literal text, not traversal', () => {
+    // %2e%2e is validated as literal characters, then encoded again on URL
+    // build — it can never decode into ".." server-side.
+    assert.deepEqual(sanitizeRemotePath('%2e%2e/file.txt'), ['%2e%2e', 'file.txt']);
+  });
+});
+
+// ---------- validateHttpsUrl ----------
+
+describe('validateHttpsUrl', () => {
+  it('accepts a plain HTTPS collection URL', () => {
+    assert.equal(validateHttpsUrl('https://myfiles.fastmail.com/', 'x').hostname, 'myfiles.fastmail.com');
+    assert.equal(validateHttpsUrl('https://cloud.example.com/remote.php/dav/files/user/', 'x').pathname, '/remote.php/dav/files/user/');
+  });
+  it('rejects HTTP', () => {
+    assert.throws(() => validateHttpsUrl('http://myfiles.fastmail.com/', 'x'), /HTTPS/);
+  });
+  it('rejects embedded userinfo', () => {
+    assert.throws(() => validateHttpsUrl('https://user:pass@host.example/', 'x'), /embed credentials/); // allowlist-secret (synthetic URL fixture)
+  });
+  it('rejects query and fragment', () => {
+    assert.throws(() => validateHttpsUrl('https://host.example/dav/?x=1', 'x'), /query or fragment/);
+    assert.throws(() => validateHttpsUrl('https://host.example/dav/#frag', 'x'), /query or fragment/);
+  });
+});
+
+// ---------- WebDAVFilesClient.uploadBuffer ----------
+
+describe('WebDAVFilesClient.uploadBuffer', () => {
+  function makeClient() {
+    const client = new WebDAVFilesClient({
+      baseUrl: 'https://files.example.com/dav', // no trailing slash on purpose
+      username: 'user@example.com',
+      password: 'app-password',
+    });
+    const dav = {
+      createObject: mock.fn(async () => new Response(null, { status: 201, statusText: 'Created' })),
+      // PROPFIND existence pre-check → absent; MKCOL → created.
+      davRequest: mock.fn(async ({ init }: any) => [{ status: init.method === 'PROPFIND' ? 404 : 201 }]),
+    };
+    (client as any).dav = dav;
+    const callsBy = (method: string) => dav.davRequest.mock.calls.filter((c: any) => c.arguments[0].init.method === method);
+    return { client, dav, callsBy };
+  }
+
+  it('PUTs to base + encoded segments with If-None-Match by default', async () => {
+    const { client, dav } = makeClient();
+    const result = await client.uploadBuffer(Buffer.from('data'), 'sub dir/räport.pdf', { contentType: 'application/pdf' });
+
+    const call = dav.createObject.mock.calls[0].arguments[0];
+    assert.equal(call.url, 'https://files.example.com/dav/sub%20dir/r%C3%A4port.pdf');
+    assert.equal(call.headers['If-None-Match'], '*');
+    assert.equal(call.headers['Content-Type'], 'application/pdf');
+    assert.ok(call.headers['authorization'] || call.headers['Authorization'], 'must send Basic auth header');
+    assert.deepEqual(result, { savedPath: 'sub dir/räport.pdf', host: 'files.example.com', bytes: 4, contentType: 'application/pdf' });
+  });
+
+  it('overwrite: true drops the If-None-Match precondition', async () => {
+    const { client, dav } = makeClient();
+    await client.uploadBuffer(Buffer.from('x'), 'a.txt', { overwrite: true });
+    assert.equal('If-None-Match' in dav.createObject.mock.calls[0].arguments[0].headers, false);
+  });
+
+  it('maps 412 to the exists/overwrite guidance', async () => {
+    const { client } = makeClient();
+    (client as any).dav.createObject = mock.fn(async () => new Response(null, { status: 412, statusText: 'Precondition Failed' }));
+    await assert.rejects(() => client.uploadBuffer(Buffer.from('x'), 'a.txt'), /already exists.*overwrite/s);
+  });
+
+  it('creates parent collections via MKCOL, tolerating 405 (exists)', async () => {
+    const { client, dav, callsBy } = makeClient();
+    dav.davRequest.mock.mockImplementation(async ({ init }: any) =>
+      [{ status: init.method === 'PROPFIND' ? 404 : 405 }]);
+    await client.uploadBuffer(Buffer.from('x'), 'a/b/c.txt');
+    const mkcols = callsBy('MKCOL');
+    assert.equal(mkcols.length, 2); // a/, a/b/
+    assert.equal(mkcols[0].arguments[0].url, 'https://files.example.com/dav/a/');
+  });
+
+  it('pre-checks existence with PROPFIND and rejects when present (servers may ignore If-None-Match)', async () => {
+    const { client, dav } = makeClient();
+    dav.davRequest.mock.mockImplementation(async ({ init }: any) =>
+      [{ status: init.method === 'PROPFIND' ? 207 : 201 }]);
+    await assert.rejects(() => client.uploadBuffer(Buffer.from('x'), 'a.txt'), /already exists.*overwrite/s);
+    assert.equal(dav.createObject.mock.calls.length, 0);
+  });
+
+  it('overwrite: true skips the existence pre-check entirely', async () => {
+    const { client, callsBy } = makeClient();
+    await client.uploadBuffer(Buffer.from('x'), 'a.txt', { overwrite: true });
+    assert.equal(callsBy('PROPFIND').length, 0);
+  });
+
+  it('fails hard when MKCOL returns an unexpected status', async () => {
+    const { client } = makeClient();
+    (client as any).dav.davRequest = mock.fn(async ({ init }: any) =>
+      [{ status: init.method === 'PROPFIND' ? 404 : 403 }]);
+    await assert.rejects(() => client.uploadBuffer(Buffer.from('x'), 'a/b.txt'), /Could not create remote directory/);
+  });
+
+  it('skips MKCOL when createParents is false', async () => {
+    const { client, callsBy } = makeClient();
+    await client.uploadBuffer(Buffer.from('x'), 'a/b/c.txt', { createParents: false });
+    assert.equal(callsBy('MKCOL').length, 0);
+  });
+
+  it('rejects unsanitary paths before any network call', async () => {
+    const { client, dav } = makeClient();
+    await assert.rejects(() => client.uploadBuffer(Buffer.from('x'), '../escape.txt'), /must not contain|relative/);
+    assert.equal(dav.createObject.mock.calls.length, 0);
+    assert.equal(dav.davRequest.mock.calls.length, 0);
+  });
+});

--- a/src/webdav-files-client.ts
+++ b/src/webdav-files-client.ts
@@ -1,0 +1,169 @@
+import { createObject, davRequest, getBasicAuthHeaders } from 'tsdav';
+
+/**
+ * Minimal WebDAV file-storage client for saving attachments to cloud storage
+ * (Fastmail Files, Nextcloud, or any WebDAV server).
+ *
+ * Deliberately NOT built on tsdav's DAVClient account machinery — plain file
+ * collections need no account discovery. Uses the low-level helpers with an
+ * explicit Basic Authorization header.
+ *
+ * SECURITY MODEL: the base URL and credentials come exclusively from server
+ * configuration (env). Tools may only ever supply a RELATIVE remote path,
+ * which is validated segment-by-segment and encoded AFTER validation — a
+ * prompt-injected caller cannot redirect uploads to another host or smuggle
+ * traversal sequences through percent-encoding.
+ */
+
+export interface WebDAVConfig {
+  baseUrl: string; // validated HTTPS collection URL, normalized to trailing slash
+  username: string;
+  password: string;
+}
+
+/**
+ * Validate a caller-supplied relative remote path into clean segments.
+ * Rejects: control chars/NUL, backslashes, absolute paths, URL smuggling,
+ * empty segments (foo//bar, trailing /), '.', '..', oversized segments/paths.
+ * Returns the raw (unencoded) segment list; callers must encode each segment.
+ */
+export function sanitizeRemotePath(remotePath: string): string[] {
+  if (typeof remotePath !== 'string' || remotePath.length === 0) {
+    throw new Error('remotePath is required');
+  }
+  if (remotePath.length > 1024) {
+    throw new Error('remotePath is too long (max 1024 characters)');
+  }
+  // eslint-disable-next-line no-control-regex
+  if (/[\u0000-\u001f\u007f]/.test(remotePath)) {
+    throw new Error('remotePath contains control characters');
+  }
+  if (remotePath.includes('\\')) {
+    throw new Error('remotePath must use forward slashes');
+  }
+  if (remotePath.startsWith('/')) {
+    throw new Error('remotePath must be relative (no leading slash)');
+  }
+  if (remotePath.includes('://')) {
+    throw new Error('remotePath must be a path, not a URL');
+  }
+  const segments = remotePath.split('/');
+  if (segments.length > 32) {
+    throw new Error('remotePath has too many segments (max 32)');
+  }
+  for (const segment of segments) {
+    if (segment === '') {
+      throw new Error('remotePath contains an empty segment (double or trailing slash)');
+    }
+    if (segment === '.' || segment === '..') {
+      throw new Error('remotePath must not contain . or .. segments');
+    }
+    if (Buffer.byteLength(segment, 'utf8') > 255) {
+      throw new Error('remotePath segment exceeds 255 bytes');
+    }
+  }
+  return segments;
+}
+
+export class WebDAVFilesClient {
+  private config: WebDAVConfig;
+  private headers: Record<string, string>;
+  // Instance-held so tests can inject mocks, mirroring the caldav-client
+  // test idiom of swapping the underlying transport.
+  private dav = { createObject, davRequest };
+
+  constructor(config: WebDAVConfig) {
+    this.config = {
+      ...config,
+      baseUrl: config.baseUrl.endsWith('/') ? config.baseUrl : `${config.baseUrl}/`,
+    };
+    this.headers = getBasicAuthHeaders({ username: config.username, password: config.password });
+  }
+
+  /** Build the target URL from validated segments — the only URL constructor. */
+  private urlFor(segments: string[]): string {
+    return this.config.baseUrl + segments.map(encodeURIComponent).join('/');
+  }
+
+  get host(): string {
+    return new URL(this.config.baseUrl).hostname;
+  }
+
+  /**
+   * MKCOL each ancestor collection of the target. 201 = created,
+   * 405 = already exists (fine); anything else is fatal.
+   */
+  private async ensureParents(segments: string[]): Promise<void> {
+    for (let depth = 1; depth < segments.length; depth++) {
+      const url = this.urlFor(segments.slice(0, depth)) + '/';
+      const [response] = await this.dav.davRequest({
+        url,
+        init: { method: 'MKCOL', headers: this.headers, body: undefined as any },
+        convertIncoming: false,
+      });
+      const status = (response as any).status ?? (response as any).statusCode;
+      if (status !== 201 && status !== 405) {
+        throw new Error(`Could not create remote directory (${segments.slice(0, depth).join('/')}): HTTP ${status}`);
+      }
+    }
+  }
+
+  /**
+   * Upload a buffer to the validated relative path.
+   * Default refuses to replace an existing remote file (If-None-Match: *,
+   * mirroring the local download path's O_EXCL semantics); overwrite=true
+   * replaces unconditionally.
+   */
+  async uploadBuffer(
+    buffer: Buffer,
+    remotePath: string,
+    options: { contentType?: string; overwrite?: boolean; createParents?: boolean } = {},
+  ): Promise<{ savedPath: string; host: string; bytes: number; contentType: string }> {
+    const segments = sanitizeRemotePath(remotePath);
+    const contentType = options.contentType || 'application/octet-stream';
+
+    // Explicit existence pre-check when not overwriting. The PUT below also
+    // carries If-None-Match: * for RFC-compliant servers, but live testing
+    // showed Fastmail Files ignores that precondition and overwrites anyway —
+    // so the guard cannot rely on the header alone.
+    if (!options.overwrite) {
+      const [probe] = await this.dav.davRequest({
+        url: this.urlFor(segments),
+        init: { method: 'PROPFIND', headers: { ...this.headers, Depth: '0' }, body: undefined as any },
+        convertIncoming: false,
+      });
+      const probeStatus = (probe as any).status ?? (probe as any).statusCode;
+      if (probeStatus !== 404) {
+        throw new Error(`Remote file already exists: ${segments.join('/')}. Pass overwrite: true to replace it.`);
+      }
+    }
+
+    if (options.createParents !== false) {
+      await this.ensureParents(segments);
+    }
+
+    const response = await this.dav.createObject({
+      url: this.urlFor(segments),
+      data: new Uint8Array(buffer) as any,
+      headers: {
+        ...this.headers,
+        'Content-Type': contentType,
+        ...(options.overwrite ? {} : { 'If-None-Match': '*' }),
+      },
+    });
+
+    if (response.status === 412) {
+      throw new Error(`Remote file already exists: ${segments.join('/')}. Pass overwrite: true to replace it.`);
+    }
+    if (!response.ok) {
+      throw new Error(`WebDAV upload failed: HTTP ${response.status} ${response.statusText}`);
+    }
+
+    return {
+      savedPath: segments.join('/'),
+      host: this.host,
+      bytes: buffer.length,
+      contentType,
+    };
+  }
+}


### PR DESCRIPTION
Second of three capability PRs toward v1.13.0.

## What

New `save_attachment_to_webdav` tool: saves an email attachment directly to WebDAV cloud storage — **Fastmail Files** (`https://myfiles.fastmail.com/` with a Files-scoped app password) or any WebDAV server (Nextcloud etc.) — without touching local disk. Reuses `fetchAttachmentBuffer` from #94.

## Security model

- Base URL + credentials come **exclusively from env** (`FASTMAIL_WEBDAV_URL/_USERNAME/_PASSWORD`): new `validateHttpsUrl` enforces HTTPS, rejects embedded userinfo and query/fragment; both creds are `registerSecret`-ed. The tool accepts only a **relative** `remotePath` — a prompt-injected caller cannot redirect uploads to an attacker host.
- `sanitizeRemotePath`: segment-by-segment validation (control chars, backslash, absolute, `.`/`..`, `://` smuggling, 255B/segment, 32 segments, 1 KB total) with percent-encoding applied **after** validation, so encoded traversal can never decode server-side.

## Live finding worth knowing

Fastmail Files **ignores `If-None-Match: *`** on PUT and overwrites anyway. The no-clobber guard is therefore layered: the RFC precondition header **plus** an explicit PROPFIND existence pre-check. Verified live: second save correctly fails with overwrite guidance, `overwrite: true` replaces.

## Verification

- 429/429 unit tests (29 new: adversarial sanitizer table, URL validator, upload semantics incl. the pre-check), TS7 typecheck, secret scan clean.
- Live against Fastmail Files: upload under a tagged folder, exists-guard, overwrite, and full cleanup (file + folder deleted, verified 404) — account verdict RESTORED, 60/60 harness checks.

Tool count 48 → 49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)