### PR TITLE
chore(release): v1.13.0 — contacts write, WebDAV save, attachments on send

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# Fastmail MCP Server
+# Fastmail MCP Server (Unofficial)
 
-A Model Context Protocol (MCP) server that provides access to the Fastmail API, enabling AI assistants to interact with email, contacts, and calendar data.
+An **unofficial** Model Context Protocol (MCP) server that provides access to the Fastmail API, enabling AI assistants to interact with email, contacts, and calendar data.
+
+> **Disclaimer:** This is a community project. It is **not affiliated with, endorsed by, or supported by Fastmail**. "Fastmail" is a trademark of Fastmail Pty Ltd; it is used here only to describe compatibility with their public JMAP/CalDAV/WebDAV APIs. Use at your own risk under the terms of the project license.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A Model Context Protocol (MCP) server that provides access to the Fastmail API, 
 - List all contacts with full contact information
 - Get specific contacts by ID
 - Search contacts by name or email
+- Create, update, and delete contacts (JMAP ContactCard/set; requires an API token with read-write contacts scope)
 
 ### Calendar Operations
 - List all calendars and calendar events
@@ -136,7 +137,7 @@ You can install this server as a Desktop Extension for Claude Desktop using the 
 
 3. Use any of the tools (e.g. `get_recent_emails`).
 
-## Available Tools (38 Total)
+## Available Tools (52 Total)
 
 **🎯 Most Popular Tools:**
 - **check_function_availability**: Check what's available and get setup guidance  
@@ -184,6 +185,9 @@ You can install this server as a Desktop Extension for Claude Desktop using the 
 - **download_attachment**: Download an email attachment. If savePath is provided, saves the file to disk and returns the file path and size. Otherwise returns a download URL.
   - Parameters: `emailId` (required), `attachmentId` (required), `savePath` (optional)
   - `savePath` may be absolute or relative. Relative paths (including a bare filename) resolve against the download directory, so an attachment lands there in one step. Absolute paths must fall within that directory; traversal or symlink escape outside it is rejected. To save directly into your own location, set `FASTMAIL_DOWNLOAD_DIR` to that root — confinement stays on, scoped to the directory you choose.
+- **save_attachment_to_webdav**: Save an attachment directly to WebDAV cloud storage (Fastmail Files, Nextcloud, ...) without touching local disk
+  - Parameters: `emailId` (required), `attachmentId` (required), `remotePath` (required, relative), `overwrite` (default false), `createParents` (default true)
+  - The storage server and credentials come from `FASTMAIL_WEBDAV_*` env config; the tool only chooses the relative path beneath that base. Existing files are never replaced unless `overwrite: true`.
 - **advanced_search**: Advanced email search with multiple criteria
   - Parameters: `query` (optional), `from` (optional), `to` (optional), `subject` (optional), `hasAttachment` (optional), `isUnread` (optional), `mailboxId` (optional), `after` (optional), `before` (optional), `limit` (default: 50), `ascending` (optional, oldest first)
 - **get_thread**: Get all emails in a conversation thread
@@ -217,6 +221,12 @@ You can install this server as a Desktop Extension for Claude Desktop using the 
   - Parameters: `contactId` (required)
 - **search_contacts**: Search contacts by name or email
   - Parameters: `query` (required), `limit` (default: 20)
+- **create_contact**: Create a new contact (requires read-write contacts scope on the API token)
+  - Parameters: `name` `{given, surname, full}`, `emails` `[{address, label}]`, `phones` `[{number, label}]`, `addresses` `[{full, label}]`, `notes`, `addressBookId` (all optional, but a name or one email is required)
+- **update_contact**: Update an existing contact — each provided field **wholly replaces** the stored value (`emails: []` removes all emails); unspecified fields are untouched
+  - Parameters: `contactId` (required), same fields as create, `expectState` (optional JMAP state precondition)
+- **delete_contact**: Permanently delete a contact (cannot be undone)
+  - Parameters: `contactId` (required), `expectState` (optional)
 
 ### Calendar Tools
 
@@ -282,6 +292,36 @@ However, Fastmail fully supports **CalDAV** for calendar access via `caldav.fast
    ```
 
 When these variables are set, all calendar tools are available. When they are not set, calendar tools will return an error with setup instructions.
+
+### WebDAV file storage (optional)
+
+`save_attachment_to_webdav` saves attachments straight to cloud storage. Configure the target (never supplied by tools at runtime — this is deliberate, so a misbehaving caller cannot redirect uploads):
+
+```bash
+# Fastmail Files:
+export FASTMAIL_WEBDAV_URL="https://myfiles.fastmail.com/"
+export FASTMAIL_WEBDAV_USERNAME="your-email@fastmail.com"
+export FASTMAIL_WEBDAV_PASSWORD="app-password-with-files-scope"
+
+# ...or any WebDAV server, e.g. Nextcloud:
+# export FASTMAIL_WEBDAV_URL="https://cloud.example.com/remote.php/dav/files/USERNAME/"
+```
+
+The URL must be HTTPS. Note: Fastmail Files ignores the WebDAV `If-None-Match` precondition, so the tool performs an explicit existence check before non-overwrite uploads.
+
+### Email attachments on send
+
+`send_email`, `create_draft`, `edit_draft`, and `reply_email` accept an `attachments` array. Each entry uses exactly one source:
+
+- `{ "localPath": "report.pdf" }` — a file inside `FASTMAIL_DOWNLOAD_DIR` (same confinement as downloads)
+- `{ "emailId": "...", "attachmentId": "..." }` — re-attach from an existing email (zero-copy: no bytes are transferred)
+- `{ "blobId": "...", "name": "...", "type": "..." }` — an already-uploaded JMAP blob
+
+Uploads respect the server's `maxSizeUpload` (~50 MB on Fastmail). Editing a draft preserves its existing attachments.
+
+### Contacts write scope
+
+`create_contact` / `update_contact` / `delete_contact` need the API token to have **read-write** contacts scope (Settings → Privacy & Security → API tokens). Read-only tokens keep the three read tools working and fail writes with a `forbidden` error.
 
 ## Development
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "dxt_version": "0.1",
   "name": "fastmail-mcp",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "MCP server for Fastmail API integration",
   "author": {
     "name": "Jeremy Gill"
@@ -40,6 +40,38 @@
       "title": "Attachment Download Directory",
       "type": "string",
       "description": "Directory for saving email attachments (defaults to ~/Downloads/fastmail-mcp/). Path traversal protection is enforced within this directory.",
+      "required": false
+    },
+    "fastmail_caldav_username": {
+      "title": "CalDAV Username",
+      "type": "string",
+      "description": "Fastmail account email, for calendar tools via CalDAV (optional)",
+      "required": false
+    },
+    "fastmail_caldav_password": {
+      "title": "CalDAV App Password",
+      "type": "string",
+      "description": "App-specific password with Calendars scope (Settings -> Privacy & Security -> App passwords). Optional; calendar tools are disabled without it.",
+      "sensitive": true,
+      "required": false
+    },
+    "fastmail_webdav_url": {
+      "title": "WebDAV Storage URL",
+      "type": "string",
+      "description": "HTTPS base URL of a WebDAV collection for save_attachment_to_webdav (e.g. https://myfiles.fastmail.com/ for Fastmail Files, or a Nextcloud files URL). Optional.",
+      "required": false
+    },
+    "fastmail_webdav_username": {
+      "title": "WebDAV Username",
+      "type": "string",
+      "description": "Username for the WebDAV storage server (for Fastmail Files: your account email)",
+      "required": false
+    },
+    "fastmail_webdav_password": {
+      "title": "WebDAV App Password",
+      "type": "string",
+      "description": "App password for the WebDAV storage server (for Fastmail Files: an app password with the Files scope)",
+      "sensitive": true,
       "required": false
     }
   },

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "dxt_version": "0.1",
   "name": "fastmail-mcp",
   "version": "1.13.0",
-  "description": "MCP server for Fastmail API integration",
+  "description": "Unofficial MCP server for Fastmail API integration (not affiliated with or endorsed by Fastmail)",
   "author": {
     "name": "Jeremy Gill"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fastmail-mcp",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fastmail-mcp",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastmail-mcp",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "MCP server for Fastmail API integration",
   "main": "dist/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fastmail-mcp",
   "version": "1.13.0",
-  "description": "MCP server for Fastmail API integration",
+  "description": "Unofficial MCP server for Fastmail API integration (not affiliated with or endorsed by Fastmail)",
   "main": "dist/index.js",
   "type": "module",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ import { coerceRecipients, coerceStringArray, coerceBool, redactBearerTokens, re
 const server = new Server(
   {
     name: 'fastmail-mcp',
-    version: '1.12.0',
+    version: '1.13.0',
   },
   {
     capabilities: {


### PR DESCRIPTION
Release PR bundling #94 (attachments on send + updateDraft fix), #95 (save_attachment_to_webdav), and #96 (contacts write).

- Version 1.12.0 → 1.13.0 in the three synced locations (test-enforced) + lockfile.
- README: tool count 38 → 52 (the 38 was already stale), new tool documentation, and three new setup sections (WebDAV storage incl. the Fastmail Files If-None-Match caveat, attachments-on-send sources and confinement, contacts write scope).
- manifest.json: `sensitive: true` user_config entries for CalDAV and WebDAV credentials — DXT users get parity with env configuration.

## Release-candidate verification

- 443/443 unit tests, TS7 build, secret scan clean.
- Full live harness (renamed test-live-v113.mjs locally, git-ignored): **65/65 checks, account verdict RESTORED** — covering the v1.12.0 baseline suite plus contact CRUD, WebDAV upload/exists-guard/overwrite/cleanup, and attachment create/reuse/edit-preserve.

After merge: tag v1.13.0 → build-dxt publishes the release (auto-generated notes via #92, to be replaced with hand-written notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)