### PR TITLE
fix(dxt): map CalDAV/WebDAV user_config values into the server env (v1.13.1)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "dxt_version": "0.1",
   "name": "fastmail-mcp",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Unofficial MCP server for Fastmail API integration (not affiliated with or endorsed by Fastmail)",
   "author": {
     "name": "Jeremy Gill"
@@ -17,7 +17,13 @@
       "env": {
         "FASTMAIL_API_TOKEN": "${user_config.fastmail_api_token}",
         "FASTMAIL_BASE_URL": "${user_config.fastmail_base_url}",
-        "FASTMAIL_DOWNLOAD_DIR": "${user_config.fastmail_download_dir}"
+        "FASTMAIL_DOWNLOAD_DIR": "${user_config.fastmail_download_dir}",
+        "FASTMAIL_CALDAV_USERNAME": "${user_config.fastmail_caldav_username}",
+        "FASTMAIL_CALDAV_PASSWORD": "${user_config.fastmail_caldav_password}",
+        "FASTMAIL_CALDAV_DISPLAY_NAME": "${user_config.fastmail_caldav_display_name}",
+        "FASTMAIL_WEBDAV_URL": "${user_config.fastmail_webdav_url}",
+        "FASTMAIL_WEBDAV_USERNAME": "${user_config.fastmail_webdav_username}",
+        "FASTMAIL_WEBDAV_PASSWORD": "${user_config.fastmail_webdav_password}"
       }
     }
   },
@@ -53,6 +59,12 @@
       "type": "string",
       "description": "App-specific password with Calendars scope (Settings -> Privacy & Security -> App passwords). Optional; calendar tools are disabled without it.",
       "sensitive": true,
+      "required": false
+    },
+    "fastmail_caldav_display_name": {
+      "title": "CalDAV Display Name",
+      "type": "string",
+      "description": "Display name used as ORGANIZER when creating calendar events with participants (defaults to the CalDAV username)",
       "required": false
     },
     "fastmail_webdav_url": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fastmail-mcp",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fastmail-mcp",
-      "version": "1.13.0",
+      "version": "1.13.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastmail-mcp",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Unofficial MCP server for Fastmail API integration (not affiliated with or endorsed by Fastmail)",
   "main": "dist/index.js",
   "type": "module",

--- a/src/caldav-client.test.ts
+++ b/src/caldav-client.test.ts
@@ -2,6 +2,7 @@ import { describe, it, mock } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   extractVEvent,
+  resolveDisplayName,
   parseICalValue,
   findValueBoundary,
   parseAllICalProperties,
@@ -2403,5 +2404,18 @@ describe('CalDAV write status checking (assertDavOk)', () => {
   it('succeeds on a 2xx status', async () => {
     const client = mockClientWithStatus(204);
     await client.updateCalendarEvent('s@fm', { title: 'X' });
+  });
+});
+
+describe('resolveDisplayName', () => {
+  it('uses the env value when it is a real string', () => {
+    assert.equal(resolveDisplayName('Jeremy G', 'fallback@example.com'), 'Jeremy G');
+  });
+  it('falls back when unset or blank', () => {
+    assert.equal(resolveDisplayName(undefined, 'fb'), 'fb');
+    assert.equal(resolveDisplayName('   ', 'fb'), 'fb');
+  });
+  it('falls back on an unresolved DXT config placeholder', () => {
+    assert.equal(resolveDisplayName('${user_config.fastmail_caldav_display_name}', 'fb'), 'fb');
   });
 });

--- a/src/caldav-client.ts
+++ b/src/caldav-client.ts
@@ -47,6 +47,18 @@ export interface CalendarEvent {
  * Extract the VEVENT block from iCalendar data.
  * This avoids matching properties from VTIMEZONE or other components.
  */
+/**
+ * Resolve the ORGANIZER display name from a raw env value, falling back when
+ * it is unset, blank, or an unresolved DXT config placeholder like
+ * "${user_config.fastmail_caldav_display_name}" — a raw process.env read here
+ * would otherwise embed the literal placeholder into generated iCal.
+ */
+export function resolveDisplayName(raw: string | undefined, fallback: string): string {
+  const trimmed = raw?.trim();
+  if (!trimmed || /\$\{[^}]+\}/.test(trimmed)) return fallback;
+  return trimmed;
+}
+
 export function extractVEvent(data: string): string | null {
   const match = data.match(/BEGIN:VEVENT[\s\S]*?END:VEVENT/);
   return match ? match[0] : null;
@@ -1176,7 +1188,7 @@ export class CalDAVCalendarClient {
       // into the ORGANIZER line when embedded below.
       const caldavUsername = this.config.username;
       validateAttendeeEmail(caldavUsername);
-      const displayName = process.env.FASTMAIL_CALDAV_DISPLAY_NAME || caldavUsername;
+      const displayName = resolveDisplayName(process.env.FASTMAIL_CALDAV_DISPLAY_NAME, caldavUsername);
       const cnPart = `;CN=${quoteParamValue(displayName)}`;
       icalLines.push(foldICalLine(`ORGANIZER${cnPart}:mailto:${caldavUsername}`));
 
@@ -1429,7 +1441,7 @@ export class CalDAVCalendarClient {
         if (!caldavUsername.includes('@')) {
           throw new Error('Cannot add participants: CalDAV username is not an email address, required for ORGANIZER');
         }
-        const displayName = process.env.FASTMAIL_CALDAV_DISPLAY_NAME || caldavUsername;
+        const displayName = resolveDisplayName(process.env.FASTMAIL_CALDAV_DISPLAY_NAME, caldavUsername);
         const cnPart = displayName ? `;CN=${quoteParamValue(displayName)}` : '';
         data = replaceICalProperty(data, 'ORGANIZER', fold(`ORGANIZER${cnPart}:mailto:${caldavUsername}`));
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ import { coerceRecipients, coerceStringArray, coerceBool, redactBearerTokens, re
 const server = new Server(
   {
     name: 'fastmail-mcp',
-    version: '1.13.0',
+    version: '1.13.1',
   },
   {
     capabilities: {
@@ -108,10 +108,14 @@ function initializeCalDAVClient(): CalDAVCalendarClient | null {
   const username = findEnvValue([
     'FASTMAIL_CALDAV_USERNAME',
     'USER_CONFIG_FASTMAIL_CALDAV_USERNAME',
+    'USER_CONFIG_fastmail_caldav_username',
+    'fastmail_caldav_username',
   ]).value;
   const password = findEnvValue([
     'FASTMAIL_CALDAV_PASSWORD',
     'USER_CONFIG_FASTMAIL_CALDAV_PASSWORD',
+    'USER_CONFIG_fastmail_caldav_password',
+    'fastmail_caldav_password',
   ]).value;
 
   if (!username || !password) return null;
@@ -133,14 +137,20 @@ function initializeWebDAVClient(): WebDAVFilesClient | null {
   const baseUrl = findEnvValue([
     'FASTMAIL_WEBDAV_URL',
     'USER_CONFIG_FASTMAIL_WEBDAV_URL',
+    'USER_CONFIG_fastmail_webdav_url',
+    'fastmail_webdav_url',
   ]).value;
   const username = findEnvValue([
     'FASTMAIL_WEBDAV_USERNAME',
     'USER_CONFIG_FASTMAIL_WEBDAV_USERNAME',
+    'USER_CONFIG_fastmail_webdav_username',
+    'fastmail_webdav_username',
   ]).value;
   const password = findEnvValue([
     'FASTMAIL_WEBDAV_PASSWORD',
     'USER_CONFIG_FASTMAIL_WEBDAV_PASSWORD',
+    'USER_CONFIG_fastmail_webdav_password',
+    'fastmail_webdav_password',
   ]).value;
 
   if (!baseUrl || !username || !password) return null;


### PR DESCRIPTION
v1.13.0's DXT collected the new CalDAV/WebDAV credentials in `user_config` but `server.mcp_config.env` never exported them — Claude Desktop users who filled them in got "not configured" errors from every calendar tool and `save_attachment_to_webdav`, with no hint why.

## Changes

- Six missing env mappings added to `server.mcp_config.env` (the five collected creds plus `FASTMAIL_CALDAV_DISPLAY_NAME`, which also gains the `user_config` prompt it never had).
- Lowercase/bare `USER_CONFIG_*` fallbacks added to the CalDAV/WebDAV env-key lists (consistency with the original three vars).
- New `resolveDisplayName()` guard: the display name was the one raw `process.env` read not protected against unresolved `${user_config...}` placeholders, which could have been embedded literally into iCal ORGANIZER lines.

## Verification

- 446/446 unit tests (3 new for the guard), TS7 build, secret scan clean.
- `npx @anthropic-ai/dxt pack`: packed manifest verified to carry all 9 env mappings, 9 user_config entries, version 1.13.1.
- dist sanity: launched with empty strings AND literal placeholders for all optional fields — calendar and WebDAV tools correctly report "not configured"; nothing leaks.

Version 1.13.0 → 1.13.1 (patch; DXT users should install the v1.13.1 asset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)