### PR TITLE
fix(dxt): root-anchor .dxtignore so runtime deps survive packing (v1.13.2)

### DIFF
--- a/.dxtignore
+++ b/.dxtignore
@@ -2,28 +2,33 @@
 # The runtime entry point is dist/index.js, so source and tests must NOT ship —
 # this is what prevents a test fixture (or any source-only data) from ever being
 # published inside a release binary.
+#
+# IMPORTANT: directory patterns are ROOT-ANCHORED (leading slash). An unanchored
+# "src/" matches at any depth and once stripped node_modules/debug/src/ — the
+# entry point of a runtime dependency — producing a .dxt that crashed on boot.
+# Anchor anything that should only match the repository root.
 
 # Source & tests (compiled output lives in dist/)
-src/
+/src/
 *.test.ts
 *.test.js
 *.test.mjs
 
 # Local/live test scripts (also gitignored)
-test-live*
-.secret-scan-local.txt
+/test-live*
+/.secret-scan-local.txt
 
 # Tooling / CI / repo scaffolding — not needed at runtime
-scripts/
-.github/
-.githooks/
-.gitignore
-.dxtignore
-.mcp.json
-tsconfig.json
+/scripts/
+/.github/
+/.githooks/
+/.gitignore
+/.dxtignore
+/.mcp.json
+/tsconfig.json
 .env
 .env.*
 
 # Dev docs / meta
-CLAUDE.md
-.secret-scan-local.txt.example
+/CLAUDE.md
+/.secret-scan-local.txt.example

--- a/.github/workflows/build-dxt.yml
+++ b/.github/workflows/build-dxt.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Drop dev dependencies from the archive
+        run: npm prune --omit=dev
+
       - name: Pack DXT
         run: npx --yes @anthropic-ai/dxt@0.2.6 pack
 
@@ -40,6 +43,21 @@ jobs:
           FILE=$(ls -1 *.dxt | head -n1)
           mv "$FILE" "fastmail-mcp-$VERSION.dxt"
           echo "DXT_FILE=fastmail-mcp-$VERSION.dxt" >> $GITHUB_ENV
+
+      - name: Boot-smoke the packed artifact
+        shell: bash
+        # Unpack the exact archive we are about to publish and prove it boots.
+        # A .dxtignore pattern once stripped a runtime dependency's entry point
+        # (node_modules/debug/src) and the .dxt died silently on initialize —
+        # this gate makes that class of packaging bug unpublishable.
+        run: |
+          set -euo pipefail
+          TMP=$(mktemp -d)
+          unzip -q "$DXT_FILE" -d "$TMP"
+          REQ='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"dxt-boot-smoke","version":"0.0.0"}}}'
+          OUT=$(printf '%s\n' "$REQ" | FASTMAIL_API_TOKEN=dummy-boot-smoke timeout 30s node "$TMP/dist/index.js")
+          grep -q '"serverInfo"' <<< "$OUT" || { echo "packed .dxt failed to answer initialize" >&2; exit 1; }
+          echo "packed artifact boots and answers initialize"
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "dxt_version": "0.1",
   "name": "fastmail-mcp",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "Unofficial MCP server for Fastmail API integration (not affiliated with or endorsed by Fastmail)",
   "author": {
     "name": "Jeremy Gill"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fastmail-mcp",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fastmail-mcp",
-      "version": "1.13.1",
+      "version": "1.13.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastmail-mcp",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "Unofficial MCP server for Fastmail API integration (not affiliated with or endorsed by Fastmail)",
   "main": "dist/index.js",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ import { coerceRecipients, coerceStringArray, coerceBool, redactBearerTokens, re
 const server = new Server(
   {
     name: 'fastmail-mcp',
-    version: '1.13.1',
+    version: '1.13.2',
   },
   {
     capabilities: {


### PR DESCRIPTION
Every `.dxt` built since `88dbf6d` (July 5) crashes silently in Claude Desktop: the unanchored `src/` pattern in `.dxtignore` matches at any depth (gitignore semantics) and stripped `node_modules/debug/src/` — the entry point of a runtime dependency that tsdav imports at module scope. The server died ~170 ms after `initialize` with nothing on stderr; the only evidence was `import-failed` in Desktop's **main.log**. Nobody had installed a DXT since the pattern landed, so it surfaced only today.

## Changes

- **`.dxtignore`**: all repo-scoped patterns root-anchored (`/src/`, `/scripts/`, …) with a comment documenting this exact failure; global `*.test.*` patterns kept (stripping dependency test files is safe and slims the archive).
- **`build-dxt.yml`**: `npm prune --omit=dev` before packing (drops typescript/tsx/@types — 2372 → 2098 files), plus a **boot-smoke gate**: unpack the exact artifact being published, pipe an MCP `initialize`, require a `serverInfo` response. This makes any future packaging bug of this class unpublishable.
- Version → **1.13.2**.

## Verification

- Packed archive verified: `node_modules/debug/src/index.js` present, no `typescript/`, no repo `src/`.
- Unpacked artifact boots: `initialize` OK, `tools/list` = 52.
- 446/446 unit tests, secret scan clean.

After merge + tag: advisories go on v1.13.0 and v1.13.1 pointing DXT users here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)