### PR TITLE
fix: report WebDAV files availability in check_function_availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ You can install this server as a Desktop Extension for Claude Desktop using the 
 - **search_emails**: Search emails by content
   - Parameters: `query` (required), `limit` (default: 20, max: 100), `ascending` (optional, oldest first), `excludeDrafts` (optional, omit draft messages)
   - Drafts are **included by default**. Set `excludeDrafts: true` to filter them out server-side.
+  - Searches **all mailboxes including Trash and Spam**. For cleanup/verification flows, exclude the Trash mailbox explicitly (e.g. `advanced_search` with `excludeMailboxIds`) rather than trusting a bare search count.
 - **get_recent_emails**: Get the most recent emails (inspired by JMAP-Samples top-ten)
   - Parameters: `limit` (default: 10, max: 50), `mailboxName` (optional), `ascending` (optional, oldest first)
   - When `mailboxName` is omitted, all mailboxes are searched **except Trash and Spam**. Pass a mailbox name (e.g. `'inbox'`, `'sent'`) to scope to one folder.
@@ -202,6 +203,7 @@ You can install this server as a Desktop Extension for Claude Desktop using the 
   - The storage server and credentials come from `FASTMAIL_WEBDAV_*` env config; the tool only chooses the relative path beneath that base. Existing files are never replaced unless `overwrite: true`.
 - **advanced_search**: Advanced email search with multiple criteria
   - Parameters: `query` (optional), `from` (optional), `to` (optional), `subject` (optional), `hasAttachment` (optional), `isUnread` (optional), `isPinned` (optional), `mailboxId` (optional), `requiredMailboxIds` (optional array — email must be in ALL of these), `excludeMailboxIds` (optional array — exclude emails in any of these), `after` (optional), `before` (optional), `limit` (default: 50, max: 100), `ascending` (optional, oldest first)
+  - Like `search_emails`, searches **all mailboxes including Trash and Spam** — scope with `mailboxId`/`excludeMailboxIds` when that matters. (`get_recent_emails` is the one that excludes Trash/Spam by default.)
 - **advanced_search_metadata**: Same filters as `advanced_search`, metadata-only results (no body content)
 - **get_thread**: Get all emails in a conversation thread
   - Parameters: `threadId` (required), `includeDrafts` (optional, include in-progress drafts)

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import { FastmailAuth, FastmailConfig } from './auth.js';
 import { JmapClient, QueryResult } from './jmap-client.js';
 import { ContactsCalendarClient } from './contacts-calendar.js';
 import { CalDAVCalendarClient } from './caldav-client.js';
-import { WebDAVFilesClient } from './webdav-files-client.js';
+import { WebDAVFilesClient, filesAvailabilitySection } from './webdav-files-client.js';
 import { validateHttpsUrl } from './url-validation.js';
 import { coerceRecipients, coerceStringArray, coerceBool, redactBearerTokens, registerSecret } from './coerce.js';
 
@@ -2649,6 +2649,15 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
               documentation: 'https://www.fastmail.com/help/technical/jmap-api.html'
             }
           },
+          files: (() => {
+            // A malformed configured URL makes initializeWebDAVClient throw —
+            // availability must report that, not fail the whole call.
+            try {
+              return filesAvailabilitySection(initializeWebDAVClient() !== null);
+            } catch (e) {
+              return filesAvailabilitySection(true, e instanceof Error ? redactBearerTokens(e.message) : String(e));
+            }
+          })(),
           capabilities: Object.keys(session.capabilities)
         };
         

--- a/src/webdav-files-client.test.ts
+++ b/src/webdav-files-client.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, mock } from 'node:test';
 import assert from 'node:assert/strict';
-import { WebDAVFilesClient, sanitizeRemotePath } from './webdav-files-client.js';
+import { WebDAVFilesClient, sanitizeRemotePath, filesAvailabilitySection } from './webdav-files-client.js';
 import { validateHttpsUrl } from './url-validation.js';
 
 // ---------- sanitizeRemotePath ----------
@@ -146,5 +146,31 @@ describe('WebDAVFilesClient.uploadBuffer', () => {
     await assert.rejects(() => client.uploadBuffer(Buffer.from('x'), '../escape.txt'), /must not contain|relative/);
     assert.equal(dav.createObject.mock.calls.length, 0);
     assert.equal(dav.davRequest.mock.calls.length, 0);
+  });
+});
+
+// ---------- filesAvailabilitySection ----------
+
+describe('filesAvailabilitySection', () => {
+  it('reports available with no guide when configured and healthy', () => {
+    const s = filesAvailabilitySection(true);
+    assert.equal(s.available, true);
+    assert.deepEqual(s.functions, ['save_attachment_to_webdav']);
+    assert.equal(s.enablementGuide, null);
+    assert.match(s.note, /configured/);
+  });
+
+  it('reports unavailable with setup guide when unconfigured', () => {
+    const s = filesAvailabilitySection(false);
+    assert.equal(s.available, false);
+    assert.match(s.note, /not configured/);
+    assert.ok(s.enablementGuide && s.enablementGuide.steps.some((x) => x.includes('myfiles.fastmail.com')));
+  });
+
+  it('configured-but-broken reports unavailable with the error, not a throw', () => {
+    const s = filesAvailabilitySection(true, 'FASTMAIL_WEBDAV_URL must use HTTPS (got: http:).');
+    assert.equal(s.available, false);
+    assert.match(s.note, /invalid.*HTTPS/s);
+    assert.ok(s.enablementGuide, 'broken config should still include the guide');
   });
 });

--- a/src/webdav-files-client.ts
+++ b/src/webdav-files-client.ts
@@ -65,6 +65,40 @@ export function sanitizeRemotePath(remotePath: string): string[] {
   return segments;
 }
 
+/**
+ * Build the `files` section for check_function_availability. Pure so it can be
+ * unit-tested without importing the server entry point (which starts the
+ * server on import). `errorNote` carries a configuration error (e.g. a
+ * malformed FASTMAIL_WEBDAV_URL) — configured-but-broken reports unavailable
+ * with the reason rather than throwing the whole availability call.
+ */
+export function filesAvailabilitySection(configured: boolean, errorNote?: string): {
+  available: boolean;
+  functions: string[];
+  note: string;
+  enablementGuide: { steps: string[]; documentation: string } | null;
+} {
+  const available = configured && !errorNote;
+  return {
+    available,
+    functions: ['save_attachment_to_webdav'],
+    note: available
+      ? 'WebDAV file storage is configured (FASTMAIL_WEBDAV_URL)'
+      : errorNote
+        ? `WebDAV storage configuration is invalid: ${errorNote}`
+        : 'WebDAV file storage not configured - set FASTMAIL_WEBDAV_URL, FASTMAIL_WEBDAV_USERNAME, and FASTMAIL_WEBDAV_PASSWORD',
+    enablementGuide: available ? null : {
+      steps: [
+        '1. For Fastmail Files: set FASTMAIL_WEBDAV_URL=https://myfiles.fastmail.com/',
+        '2. Create an app password with the Files scope (Settings → Privacy & Security → App passwords)',
+        '3. Set FASTMAIL_WEBDAV_USERNAME (your account email) and FASTMAIL_WEBDAV_PASSWORD (the app password)',
+        '4. Any other WebDAV server works too — point FASTMAIL_WEBDAV_URL at its HTTPS collection URL',
+      ],
+      documentation: 'https://www.fastmail.com/help/files/davnav.html',
+    },
+  };
+}
+
 export class WebDAVFilesClient {
   private config: WebDAVConfig;
   private headers: Record<string, string>;


### PR DESCRIPTION
Found by live DXT testing (guided Desktop run): `check_function_availability` reports mail/identity/contacts/calendar but **no files section** — even when `FASTMAIL_WEBDAV_*` is configured and `save_attachment_to_webdav` demonstrably works. The section was specified in #95's design but never wired into the handler; reproduced live against a running v1.13.2 instance before fixing.

## Changes

- New pure `filesAvailabilitySection()` builder in `src/webdav-files-client.ts` (the server entry point can't be imported in tests, so the logic lives where it's unit-testable), wired into the handler with a try/catch: a malformed `FASTMAIL_WEBDAV_URL` reports `available: false` with the redacted validation error instead of failing the whole availability call.
- Three states covered: unconfigured (env-var note + Fastmail Files enablement guide), configured-and-healthy, configured-but-invalid.
- README: documents that `search_emails`/`advanced_search` search **all mailboxes including Trash/Spam** (unlike `get_recent_emails`) — cleanup/verification flows should exclude Trash explicitly. Also from the test report.

## Verification

- 449/449 unit tests (3 new), TS7 typecheck, secret scan clean.
- Live before-snapshot: the running v1.13.2 instance returns no `files` key; the section builder's three states are unit-pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)