### PR TITLE
chore(release): v1.13.3 — complete availability report

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "dxt_version": "0.1",
   "name": "fastmail-mcp",
-  "version": "1.13.2",
+  "version": "1.13.3",
   "description": "Unofficial MCP server for Fastmail API integration (not affiliated with or endorsed by Fastmail)",
   "author": {
     "name": "Jeremy Gill"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fastmail-mcp",
-  "version": "1.13.2",
+  "version": "1.13.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fastmail-mcp",
-      "version": "1.13.2",
+      "version": "1.13.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastmail-mcp",
-  "version": "1.13.2",
+  "version": "1.13.3",
   "description": "Unofficial MCP server for Fastmail API integration (not affiliated with or endorsed by Fastmail)",
   "main": "dist/index.js",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ import { coerceRecipients, coerceStringArray, coerceBool, redactBearerTokens, re
 const server = new Server(
   {
     name: 'fastmail-mcp',
-    version: '1.13.2',
+    version: '1.13.3',
   },
   {
     capabilities: {


### PR DESCRIPTION
Patch release so the installed DXT's `check_function_availability` includes the new `files`/WebDAV section (#101) and the Trash-scope documentation. No functional changes beyond #101.

- Version 1.13.2 → 1.13.3 in the three synced locations (test-enforced) + lockfile.
- 449/449 tests, secret scan clean.

After merge: tag v1.13.3 → boot-smoked DXT build → release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)