### PR TITLE
Accept Fastmail regional JMAP endpoints in the host allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ An **unofficial** Model Context Protocol (MCP) server that provides access to th
    ```bash
    export FASTMAIL_API_TOKEN="your_api_token_here"
    # Optional: customize base URL (defaults to https://api.fastmail.com)
-   # Only api.fastmail.com and www.fastmailusercontent.com are accepted by default.
+   # Only api.fastmail.com and www.fastmailusercontent.com are accepted by default,
+   # each with an optional regional prefix (phl.api.fastmail.com,
+   # phl-www.fastmailusercontent.com) as returned by JMAP session discovery.
    # For self-hosted JMAP servers, also set FASTMAIL_ALLOW_UNSAFE_BASE_URL=true.
    export FASTMAIL_BASE_URL="https://api.fastmail.com"
    # Optional: customize attachment download directory (defaults to ~/Downloads/fastmail-mcp/).

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,8 @@ function getAuthConfig(): FastmailConfig {
   ]);
 
   // Opt-in for self-hosted JMAP servers. Required to use any base URL outside
-  // the api.fastmail.com / www.fastmailusercontent.com allowlist.
+  // the api.fastmail.com / www.fastmailusercontent.com allowlist (which already
+  // covers Fastmail's regional hosts, e.g. phl.api.fastmail.com).
   const unsafeInfo = findEnvValue([
     'FASTMAIL_ALLOW_UNSAFE_BASE_URL',
   ]);

--- a/src/url-validation.test.ts
+++ b/src/url-validation.test.ts
@@ -13,6 +13,65 @@ describe('validateFastmailUrl (default policy)', () => {
     assert.equal(url.hostname, 'www.fastmailusercontent.com');
   });
 
+  it('accepts a regional API host', () => {
+    // Fastmail session discovery returns region-pinned endpoints for some
+    // accounts, e.g. apiUrl/uploadUrl on phl.api.fastmail.com.
+    const url = validateFastmailUrl('https://phl.api.fastmail.com/jmap/api/', 'session.apiUrl');
+    assert.equal(url.hostname, 'phl.api.fastmail.com');
+  });
+
+  it('accepts a regional user-content host', () => {
+    // The user-content host spells the region with a hyphen, not a dot.
+    const url = validateFastmailUrl(
+      'https://phl-www.fastmailusercontent.com/jmap/download/x/y/z',
+      'session.downloadUrl',
+    );
+    assert.equal(url.hostname, 'phl-www.fastmailusercontent.com');
+  });
+
+  it('accepts a multi-part regional prefix', () => {
+    assert.equal(
+      validateFastmailUrl('https://us-west1.api.fastmail.com/jmap/api/', 'apiUrl').hostname,
+      'us-west1.api.fastmail.com',
+    );
+    assert.equal(
+      validateFastmailUrl('https://us-west1-www.fastmailusercontent.com/x', 'downloadUrl').hostname,
+      'us-west1-www.fastmailusercontent.com',
+    );
+  });
+
+  it('rejects a regional prefix carrying extra labels', () => {
+    // Only one label may precede the fixed suffix, so an attacker-controlled
+    // host cannot hide in front of a legitimate-looking regional prefix.
+    assert.throws(
+      () => validateFastmailUrl('https://evil.phl.api.fastmail.com/jmap/api/', 'baseUrl'),
+      /not in the Fastmail allowlist/,
+    );
+    assert.throws(
+      () => validateFastmailUrl('https://evil.phl-www.fastmailusercontent.com/x', 'baseUrl'),
+      /not in the Fastmail allowlist/,
+    );
+  });
+
+  it('rejects a regional-looking prefix on the wrong domain', () => {
+    assert.throws(
+      () => validateFastmailUrl('https://phl.api.fastmail.com.attacker.com/', 'baseUrl'),
+      /not in the Fastmail allowlist/,
+    );
+    assert.throws(
+      () => validateFastmailUrl('https://phl-www.fastmailusercontent.com.attacker.com/', 'baseUrl'),
+      /not in the Fastmail allowlist/,
+    );
+  });
+
+  it('rejects a regional prefix on a non-API fastmail host', () => {
+    // The prefix is only allowed in front of the two endpoint hosts.
+    assert.throws(
+      () => validateFastmailUrl('https://phl.www.fastmail.com/jmap/api/', 'baseUrl'),
+      /not in the Fastmail allowlist/,
+    );
+  });
+
   it('rejects HTTP even on allowed host', () => {
     assert.throws(
       () => validateFastmailUrl('http://api.fastmail.com/jmap/api/', 'baseUrl'),

--- a/src/url-validation.ts
+++ b/src/url-validation.ts
@@ -1,17 +1,33 @@
 // Validates URLs that will receive the bearer token. Restricts to approved
 // Fastmail origins by default, with an explicit opt-out for self-hosted JMAP.
 
-const FASTMAIL_ALLOWED_HOSTS: ReadonlySet<string> = new Set([
-  'api.fastmail.com',
-  'www.fastmailusercontent.com',
-]);
+// Fastmail's session discovery hands back region-pinned endpoints, so the
+// allowlist matches host *shapes*, not a fixed list of names. Observed live:
+//   apiUrl / uploadUrl -> phl.api.fastmail.com   (region as a leading label)
+//   downloadUrl        -> phl-www.fastmailusercontent.com  (region hyphenated
+//                                                           onto the `www` label)
+// The two hosts spell the region differently, hence two patterns. Both are
+// anchored at each end and the region part excludes `.`, so a single label is
+// all that can precede the fixed suffix — `evil.phl-www.fastmailusercontent.com`
+// and `evilapi.fastmail.com.attacker.com` both still fail.
+const REGION = '[a-z0-9]+(?:-[a-z0-9]+)*';
+const FASTMAIL_ALLOWED_HOST_PATTERNS: readonly RegExp[] = [
+  new RegExp(`^(?:${REGION}\\.)?api\\.fastmail\\.com$`),
+  new RegExp(`^(?:${REGION}-)?www\\.fastmailusercontent\\.com$`),
+];
+
+function isAllowedFastmailHost(hostname: string): boolean {
+  // URL parsing already lowercases and punycodes the hostname.
+  return FASTMAIL_ALLOWED_HOST_PATTERNS.some((re) => re.test(hostname));
+}
 
 /**
  * Validate that a URL is acceptable for sending the bearer token to.
  *
  * Default policy:
  *   - Must be HTTPS.
- *   - Hostname must be in FASTMAIL_ALLOWED_HOSTS.
+ *   - Hostname must match FASTMAIL_ALLOWED_HOST_PATTERNS: Fastmail's API and
+ *     user-content hosts, with or without a regional prefix.
  *
  * When `allowUnsafe=true` (e.g. user opted in via FASTMAIL_ALLOW_UNSAFE_BASE_URL
  * for a self-hosted JMAP server):
@@ -34,16 +50,16 @@ export function validateFastmailUrl(input: string, fieldName: string, allowUnsaf
       `Plain HTTP is rejected because the bearer token would be sent in cleartext.`,
     );
   }
-  if (!allowUnsafe && !FASTMAIL_ALLOWED_HOSTS.has(parsed.hostname)) {
+  if (!allowUnsafe && !isAllowedFastmailHost(parsed.hostname)) {
     throw new Error(
-      `${fieldName} host '${parsed.hostname}' is not in the Fastmail allowlist. ` +
+      `${fieldName} host '${parsed.hostname}' is not in the Fastmail allowlist ` +
+      `(api.fastmail.com and www.fastmailusercontent.com, each with an optional ` +
+      `regional prefix such as phl.api.fastmail.com). ` +
       `Set FASTMAIL_ALLOW_UNSAFE_BASE_URL=true to opt in for self-hosted JMAP servers.`,
     );
   }
   return parsed;
 }
-
-export const FASTMAIL_ALLOWED_HOSTS_FOR_TEST = FASTMAIL_ALLOWED_HOSTS;
 
 /**
  * Validate a user-configured HTTPS endpoint (e.g. the WebDAV base URL).


### PR DESCRIPTION
Closes #105

Fastmail's JMAP session discovery pins some accounts to a regional endpoint. On a `phl`-served account, `GET /jmap/session` returns `apiUrl` and `uploadUrl` on `phl.api.fastmail.com` and `downloadUrl` on `phl-www.fastmailusercontent.com`. The exact-match host set in `validateFastmailUrl` rejected all three, so the session parse threw on connect and every tool failed with:

```
session.apiUrl host 'phl.api.fastmail.com' is not in the Fastmail allowlist.
```

The error's suggested remedy, `FASTMAIL_ALLOW_UNSAFE_BASE_URL`, is the self-hosted-JMAP opt-in and would disable host checking for every URL in the session response - much broader than accepting Fastmail's own regional host.

### What changed

The allowlist now matches host *shapes*: an optional regional prefix in front of `api.fastmail.com` (as a leading label) and in front of `www.fastmailusercontent.com` (hyphenated onto the `www` label). Two patterns rather than one, because the two hosts spell the region differently.

Also drops the unused `FASTMAIL_ALLOWED_HOSTS_FOR_TEST` export, which no longer has a set to point at.

### Security posture

Unchanged apart from the intended widening:

- HTTPS is still mandatory in every mode, including the unsafe opt-in.
- The region part excludes `.` and both patterns are anchored at each end, so a nested prefix (`evil.phl-www.fastmailusercontent.com`) and a foreign registrable domain behind the suffix (`phl.api.fastmail.com.attacker.com`) are still rejected.
- The prefix is only accepted in front of the two endpoint hosts - `phl.www.fastmail.com` is still rejected.
- `FASTMAIL_ALLOW_UNSAFE_BASE_URL` is untouched and is no longer needed for a regional Fastmail account.

### Testing

Six new cases in `src/url-validation.test.ts` cover the two regional hosts, a multi-part region label, and each of the three rejections above; the pre-existing suffix-attack and scheme cases are unchanged and still pass.

Verified live against a `phl`-served account: the session parse accepts all three endpoint URLs and tool calls succeed.

Note: three pre-existing tests in `src/jmap-client.test.ts` fail on my machine with `EPERM: symlink` - creating symlinks on Windows needs elevation. They are untouched by this change and unrelated to it.
