### PR TITLE
Release v1.13.4 — regional JMAP endpoint support

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "dxt_version": "0.1",
   "name": "fastmail-mcp",
-  "version": "1.13.3",
+  "version": "1.13.4",
   "description": "Unofficial MCP server for Fastmail API integration (not affiliated with or endorsed by Fastmail)",
   "author": {
     "name": "Jeremy Gill"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fastmail-mcp",
-  "version": "1.13.3",
+  "version": "1.13.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fastmail-mcp",
-      "version": "1.13.3",
+      "version": "1.13.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastmail-mcp",
-  "version": "1.13.3",
+  "version": "1.13.4",
   "description": "Unofficial MCP server for Fastmail API integration (not affiliated with or endorsed by Fastmail)",
   "main": "dist/index.js",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ import { coerceRecipients, coerceStringArray, coerceBool, redactBearerTokens, re
 const server = new Server(
   {
     name: 'fastmail-mcp',
-    version: '1.13.3',
+    version: '1.13.4',
   },
   {
     capabilities: {

--- a/src/url-validation.test.ts
+++ b/src/url-validation.test.ts
@@ -95,7 +95,7 @@ describe('validateFastmailUrl (default policy)', () => {
   });
 
   it('rejects host that ends with allowlisted domain (suffix-attack)', () => {
-    // Confirms exact-match check, not endsWith.
+    // Confirms the patterns are anchored at the end — a suffix match is not enough.
     assert.throws(
       () => validateFastmailUrl('https://evilapi.fastmail.com.attacker.com/', 'baseUrl'),
       /not in the Fastmail allowlist/,


### PR DESCRIPTION
Cuts v1.13.4, whose sole functional change is the already-merged #106: regional Fastmail JMAP endpoints (`phl.api.fastmail.com`, `phl-www.fastmailusercontent.com`) are now accepted by the host allowlist, unbreaking regionally-pinned accounts without the `FASTMAIL_ALLOW_UNSAFE_BASE_URL` escape hatch.

This PR contains:

- Version bump 1.13.3 → 1.13.4 in the three synced locations (`package.json`, `manifest.json`, `src/index.ts`) plus the lockfile.
- A comment touch-up in `src/url-validation.test.ts`: the suffix-attack test's comment still credited the old exact-match set; it now describes the anchored patterns that replaced it in #106. No behavior change.

Verified locally: `npm run build` clean, all 455 tests pass (including the version-sync test across the three files).

After merge, tagging `v1.13.4` triggers the DXT build + GitHub release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013VQcp84KWae6i3eVfyF2JA

---
_Generated by [Claude Code](https://claude.ai/code/session_013VQcp84KWae6i3eVfyF2JA)_