### PR TITLE
Add dispatch-only workflow to create release tags

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -1,0 +1,42 @@
+name: Create Tag
+
+# Tag creation for release flows driven from environments whose git
+# credentials cannot push refs/tags (e.g. remote coding sessions where pushes
+# are scoped to a single work branch). The repo-scoped GITHUB_TOKEN can.
+#
+# Note: a tag pushed with GITHUB_TOKEN does not itself trigger the
+# "Build and Release DXT" workflow (GitHub suppresses recursive workflow
+# triggers), so after this completes, dispatch that workflow on the new tag.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to create at the dispatched ref (e.g. v1.13.4)"
+        required: true
+        type: string
+
+# Least privilege: pushing the tag is the only write.
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Validate and create tag
+        shell: bash
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "tag '$TAG' is not vX.Y.Z" >&2; exit 1; }
+          if git ls-remote --exit-code origin "refs/tags/$TAG" >/dev/null; then
+            echo "tag $TAG already exists" >&2
+            exit 1
+          fi
+          git tag "$TAG"
+          git push origin "refs/tags/$TAG"


### PR DESCRIPTION
The DXT release pipeline (`build-dxt.yml`) triggers on tag pushes, but release flows driven from remote sessions have git credentials scoped to a single work branch — pushing `refs/tags/*` gets a 403, which is exactly what happened cutting v1.13.4 just now (the version bump merged in #107, but the tag can't be pushed from the session).

This adds a minimal dispatch-only workflow that creates the tag with the repo-scoped `GITHUB_TOKEN` instead:

- `workflow_dispatch` with a single `tag` input; runs at whatever ref it's dispatched on.
- Validates the input is `vX.Y.Z` and refuses to touch an existing tag, so it can never move a published release.
- `permissions: contents: write` only, checkout SHA-pinned to the same `actions/checkout` pin the other workflows use.

One wrinkle documented in the file: tags pushed with `GITHUB_TOKEN` don't trigger downstream workflows (GitHub suppresses recursion), so after this runs, "Build and Release DXT" is dispatched explicitly on the new tag — its release step already handles that case (`startsWith(github.ref, 'refs/tags/')` is true for a tag-ref dispatch).

Immediate use: create `v1.13.4` on `main` and publish the pending release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013VQcp84KWae6i3eVfyF2JA

---
_Generated by [Claude Code](https://claude.ai/code/session_013VQcp84KWae6i3eVfyF2JA)_