### PR TITLE
Auto-release on version bumps pushed to main

### DIFF
--- a/.github/workflows/build-dxt.yml
+++ b/.github/workflows/build-dxt.yml
@@ -5,9 +5,11 @@ on:
   push:
     tags:
       - 'v*'
+    branches:
+      - main
 
-# Least privilege: the only elevated need is creating the release + uploading
-# the .dxt asset. Everything else runs read-only.
+# Least privilege: the only elevated need is creating the release tag + the
+# release + uploading the .dxt asset. Everything else runs read-only.
 permissions:
   contents: write
 
@@ -23,6 +25,33 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+
+      # Release when the run is for a version that has no tag yet: either a
+      # pushed v* tag (including a manual create-tag.yml + dispatch flow), or a
+      # push to main whose package.json version is untagged — so merging a
+      # version bump releases it without a separately pushed tag. Non-bump main
+      # pushes and branch dispatches stay build-only.
+      - name: Determine release tag
+        id: reltag
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+            echo "release=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$GITHUB_REF" == refs/heads/main ]]; then
+            TAG="v$(node -p "require('./package.json').version")"
+            [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "unexpected version '$TAG'" >&2; exit 1; }
+            if git ls-remote --exit-code origin "refs/tags/$TAG" >/dev/null; then
+              echo "tag $TAG already exists — build-only run"
+              echo "release=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+              echo "release=true" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "release=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Install dependencies
         run: npm ci
@@ -65,10 +94,23 @@ jobs:
           name: fastmail-mcp-dxt
           path: ${{ env.DXT_FILE }}
 
+      # The tag is created only after the packed artifact has proven it boots,
+      # so a broken build can never leave a published tag behind.
+      - name: Tag the release commit
+        if: steps.reltag.outputs.release == 'true' && startsWith(github.ref, 'refs/heads/')
+        shell: bash
+        env:
+          TAG: ${{ steps.reltag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git tag "$TAG"
+          git push origin "refs/tags/$TAG"
+
       - name: Create GitHub Release
-        if: startsWith(github.ref, 'refs/tags/')
+        if: steps.reltag.outputs.release == 'true'
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
+          tag_name: ${{ steps.reltag.outputs.tag }}
           files: ${{ env.DXT_FILE }}
           # Seed the release body with the auto-generated PR list so new
           # releases never publish empty; hand-written notes can replace it.


### PR DESCRIPTION
Completes the release automation started in #108. The dispatch route turned out to be closed too: the integration token can't call the workflow-dispatch API (`actions: write` not granted), so `create-tag.yml` is only reachable from the Actions UI — and v1.13.4 (merged in #107) is still stranded untagged.

This makes `build-dxt.yml` self-sufficient:

- **Also triggers on pushes to `main`.** A new `Determine release tag` step decides per run: a pushed `v*` tag releases exactly as before; a main push whose `package.json` version has **no existing tag** creates that tag and releases; non-bump main pushes and branch dispatches are build-only (they still produce the uploaded `.dxt` artifact).
- **The tag is created only after the boot-smoke passes**, so a broken artifact can never leave a published tag behind — this actually strengthens the old flow, where the tag necessarily existed before the build was proven.
- The release step now passes `tag_name` explicitly instead of inferring it from the triggering ref, and the version string is shape-validated (`vX.Y.Z`) before use; the tag value reaches the shell via `env`, not inline interpolation.
- Permissions unchanged (`contents: write`, which already covered tag refs).

**Merging this PR is itself the pending release**: the merge is a version-bump push (1.13.4 untagged on main), so the run it triggers tags `v1.13.4` and publishes the release with the DXT asset and generated notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013VQcp84KWae6i3eVfyF2JA

---
_Generated by [Claude Code](https://claude.ai/code/session_013VQcp84KWae6i3eVfyF2JA)_